### PR TITLE
Add support for stop header image + Laravel CORS

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -14,6 +14,7 @@ class Kernel extends HttpKernel
      * @var array
      */
     protected $middleware = [
+        \Fruitcake\Cors\HandleCors::class,
         \App\Http\Middleware\TrustProxies::class,
         \App\Http\Middleware\CheckForMaintenanceMode::class,
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "require": {
         "php": "^7.2",
         "fideloper/proxy": "^4.0",
+        "fruitcake/laravel-cors": "^2.0",
         "geocoder-php/mapbox-provider": "^1.0",
         "grimzy/laravel-mysql-spatial": "^5.0.0",
         "intervention/image": "^2.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,64 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6342067b2a0e2001ba6630864fee5360",
+    "content-hash": "82aa9c9c0e21836c04621e06d68f6191",
     "packages": [
+        {
+            "name": "asm89/stack-cors",
+            "version": "v2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/asm89/stack-cors.git",
+                "reference": "73e5b88775c64ccc0b84fb60836b30dc9d92ac4a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/asm89/stack-cors/zipball/73e5b88775c64ccc0b84fb60836b30dc9d92ac4a",
+                "reference": "73e5b88775c64ccc0b84fb60836b30dc9d92ac4a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0",
+                "symfony/http-foundation": "^4|^5|^6",
+                "symfony/http-kernel": "^4|^5|^6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7|^9",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Asm89\\Stack\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alexander",
+                    "email": "iam.asm89@gmail.com"
+                }
+            ],
+            "description": "Cross-origin resource sharing library and stack middleware",
+            "homepage": "https://github.com/asm89/stack-cors",
+            "keywords": [
+                "cors",
+                "stack"
+            ],
+            "support": {
+                "issues": "https://github.com/asm89/stack-cors/issues",
+                "source": "https://github.com/asm89/stack-cors/tree/v2.1.1"
+            },
+            "time": "2022-01-18T09:12:03+00:00"
+        },
         {
             "name": "brick/math",
             "version": "0.9.3",
@@ -564,6 +620,87 @@
                 "source": "https://github.com/fideloper/TrustedProxy/tree/4.4.1"
             },
             "time": "2020-10-22T13:48:01+00:00"
+        },
+        {
+            "name": "fruitcake/laravel-cors",
+            "version": "v2.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fruitcake/laravel-cors.git",
+                "reference": "3a066e5cac32e2d1cdaacd6b961692778f37b5fc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fruitcake/laravel-cors/zipball/3a066e5cac32e2d1cdaacd6b961692778f37b5fc",
+                "reference": "3a066e5cac32e2d1cdaacd6b961692778f37b5fc",
+                "shasum": ""
+            },
+            "require": {
+                "asm89/stack-cors": "^2.0.1",
+                "illuminate/contracts": "^6|^7|^8|^9",
+                "illuminate/support": "^6|^7|^8|^9",
+                "php": ">=7.2",
+                "symfony/http-foundation": "^4|^5|^6",
+                "symfony/http-kernel": "^4.3.4|^5|^6"
+            },
+            "require-dev": {
+                "laravel/framework": "^6|^7.24|^8",
+                "orchestra/testbench-dusk": "^4|^5|^6|^7",
+                "phpunit/phpunit": "^6|^7|^8|^9",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Fruitcake\\Cors\\CorsServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Fruitcake\\Cors\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fruitcake",
+                    "homepage": "https://fruitcake.nl"
+                },
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "Adds CORS (Cross-Origin Resource Sharing) headers support in your Laravel application",
+            "keywords": [
+                "api",
+                "cors",
+                "crossdomain",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/fruitcake/laravel-cors/issues",
+                "source": "https://github.com/fruitcake/laravel-cors/tree/v2.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://fruitcake.nl",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/barryvdh",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-01-03T14:53:04+00:00"
         },
         {
             "name": "geo-io/interface",
@@ -11101,5 +11238,5 @@
         "php": "^7.2"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/config/cors.php
+++ b/config/cors.php
@@ -1,0 +1,34 @@
+<?php
+
+return [
+
+  /*
+    |--------------------------------------------------------------------------
+    | Cross-Origin Resource Sharing (CORS) Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure your settings for cross-origin resource sharing
+    | or "CORS". This determines what cross-origin operations may execute
+    | in web browsers. You are free to adjust these settings as needed.
+    |
+    | To learn more: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
+    |
+    */
+
+  'paths' => ['api/*', 'ar/*', 'sanctum/csrf-cookie'],
+
+  'allowed_methods' => ['*'],
+
+  'allowed_origins' => ['*'],
+
+  'allowed_origins_patterns' => [],
+
+  'allowed_headers' => ['*'],
+
+  'exposed_headers' => [],
+
+  'max_age' => 0,
+
+  'supports_credentials' => false,
+
+];

--- a/resources/js/components/edit/LanguageText.vue
+++ b/resources/js/components/edit/LanguageText.vue
@@ -2,7 +2,7 @@
     <div>
         <template v-if="largetext">
              <div class="row">
-                 <div v-for="(language, key) in languages" :key="key" class="form-group col-sm-6">
+                 <div v-for="(language, key) in languages" :key="key" class="form-group col">
                      <label :for="'field' + key + randomIdentifier" class=""><slot/> ({{ language }})</label>
                     <custom-markdown v-if="largetext" :text.sync="text[language]" :idkey="'field' + key + randomIdentifier"></custom-markdown>
                 </div>
@@ -14,7 +14,7 @@
             <div v-for="(language, key) in languages" :key="key">
                 <div class="form-group row">
                     <label :for="'field' + key + randomIdentifier" class="col-sm-2 col-form-label"><slot/> ({{ language }})</label>
-                    <div class="col-sm-6">
+                    <div class="col-sm-10">
                         <input type="text" class="form-control" v-model="text[language]" placeholder="" :id="'field' + key + randomIdentifier">
                     </div>
                     <div class="col-sm-4">

--- a/resources/js/components/edit/TourStop.vue
+++ b/resources/js/components/edit/TourStop.vue
@@ -1,237 +1,316 @@
 <template>
-    <div v-if="tour && stop">
-         <error :error="error"/>
-        <div class="row mb-2">
-            <div class="col">
-                <router-link :to="{'name': 'editTour', params: { tourId: tourId }}">{{tour.title }}</router-link>
-                >
-                {{ stop.stop_content.title[tour.tour_content.languages[0]] }}
+  <div v-if="tour && stop">
+    <error :error="error" />
+    <div class="mb-2">
+      <div class="mb-4">
+        <router-link :to="{ name: 'editTour', params: { tourId: tourId } }">{{
+          tour.title
+        }}</router-link>
+        >
+        {{ stop.stop_content.title[tour.tour_content.languages[0]] }}
+      </div>
+      <div>
+        <section class="mb-4">
+          <language-text
+            class="mb-4"
+            :languages="tour.tour_content.languages"
+            :text.sync="stop.stop_content.title"
+          >
+            Stop Title
+          </language-text>
+
+          <div class="form-group row">
+            <label class="col-sm-2 col-form-label" for="header-image-url">
+              Image URL</label
+            >
+            <div class="col-sm-10">
+                <input
+                type="url"
+                class="form-control"
+                id="header-image-url"
+                placeholder="https://example.com/image.jpg"
+                v-model="stop.stop_content.header_image.src"
+                />
             </div>
-        </div>
-        <div class="row">
-            <div class="col">
-                <language-text :languages="tour.tour_content.languages" :text.sync="stop.stop_content.title">
-                    Stop Title
-                </language-text>
-                <hr />
-                <draggable v-model="stop.stop_content.stages" handle=".handle">
-                    <stage v-for="(stage,key) in stop.stop_content.stages" :key='key' :stage="stage"
-                        v-on:remove="stop.stop_content.stages.splice(key, 1)">
-                        <component :is="stage.type" :stage="stage" :languages="tour.tour_content.languages"
-                            :tour="tour" :stop="stop">
-                        </component>
-                    </stage>
-                </draggable>
-
-
-
-
-
+          </div>
+          <div class="form-group row">
+            <label class="col-sm-2 col-form-label" for="header-image-alt">
+                Image Alt
+            </label
+            >
+            <div class="col-sm-10">
+                <input
+                type="text"
+                class="form-control col"
+                id="header-image-alt"
+                placeholder="Description of the image"
+                v-model="stop.stop_content.header_image.alt"
+                />
             </div>
-        </div>
-        <div class="row mt-2">
-            <div class="col-12 d-flex justify-content-between align-items-center">
-                <span>
-                    <router-link :to="{'name': 'editTour', params: { tourId: tourId }}" class="btn btn-outline-secondary">
-                        <i class="fas fa-arrow-left"></i>
-                        <span class="d-none d-sm-inline">Back to Tour</span></router-link>
-                    <a :href="previewLink" v-if="stop.id" class="btn btn-outline-success" target="_blank"><i class="fas fa-eye"></i> <span class="d-none d-sm-inline">Preview</span></a>
-                    <button @click="save" class="btn btn-primary"><i class="fas fa-save"></i> <span class="d-none d-sm-inline">Save</span></button>
-                    <save-alert :showAlert.sync="showAlert" />
-                </span>
+          </div>
+          <div class="header-image__preview">
+              <img v-if="stop.stop_content.header_image.src" :src="stop.stop_content.header_image.src" />
+          </div>
+        </section>
 
-                <div class="col-6">
-                    <div class="row d-flex justify-content-end">
-                    <select class="form-control col-3" v-model="newStageType">
-                        <option disabled></option>
-                        <option v-for="(stageType, key) in stageTypes" :key="key" :value="key">{{ stageType }}</option>
-                    </select>
-
-                        <button class="btn btn-primary" @click="addStage" :disabled="!newStageType"><i class="fas fa-plus"></i> Add a
-                            Stage</button>
-                    </div>
-                </div>
-
-            </div>
-        </div>
-
+        <draggable v-model="stop.stop_content.stages" handle=".handle">
+          <stage
+            v-for="(stage, key) in stop.stop_content.stages"
+            :key="key"
+            :stage="stage"
+            v-on:remove="stop.stop_content.stages.splice(key, 1)"
+          >
+            <component
+              :is="stage.type"
+              :stage="stage"
+              :languages="tour.tour_content.languages"
+              :tour="tour"
+              :stop="stop"
+            >
+            </component>
+          </stage>
+        </draggable>
+      </div>
     </div>
+    <div class="row mt-2">
+      <div class="col-12 d-flex justify-content-between align-items-center">
+        <span>
+          <router-link
+            :to="{ name: 'editTour', params: { tourId: tourId } }"
+            class="btn btn-outline-secondary"
+          >
+            <i class="fas fa-arrow-left"></i>
+            <span class="d-none d-sm-inline">Back to Tour</span></router-link
+          >
+          <a
+            :href="previewLink"
+            v-if="stop.id"
+            class="btn btn-outline-success"
+            target="_blank"
+            ><i class="fas fa-eye"></i>
+            <span class="d-none d-sm-inline">Preview</span></a
+          >
+          <button @click="save" class="btn btn-primary">
+            <i class="fas fa-save"></i>
+            <span class="d-none d-sm-inline">Save</span>
+          </button>
+          <save-alert :showAlert.sync="showAlert" />
+        </span>
 
+        <div class="col-6">
+          <div class="row d-flex justify-content-end">
+            <select class="form-control col-3" v-model="newStageType">
+              <option disabled></option>
+              <option
+                v-for="(stageType, key) in stageTypes"
+                :key="key"
+                :value="key"
+              >
+                {{ stageType }}
+              </option>
+            </select>
+
+            <button
+              class="btn btn-primary"
+              @click="addStage"
+              :disabled="!newStageType"
+            >
+              <i class="fas fa-plus"></i> Add a Stage
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </template>
 
 <script>
-    import draggable from 'vuedraggable'
+import draggable from "vuedraggable";
+import { get } from "lodash";
 
-    export default {
-        props: ["stopId", "tourId"],
-        components: {
-            draggable
+export default {
+  props: ["stopId", "tourId"],
+  components: {
+    draggable,
+  },
+  data() {
+    return {
+      error: null,
+      isDirty: false,
+      localStop: this.stopId,
+      showAlert: false,
+      newStageType: null,
+      stageTypes: {
+        separator: "Separator",
+        ar: "AR",
+        deepdives: "Deep Dives",
+        "embed-frame": "Embed",
+        guide: "Guide",
+        gallery: "Gallery",
+        navigation: "Navigation",
+        quiz: "Quiz",
+      },
+      tour: null,
+      stop: {
+        stop_content: {
+          title: {
+            placeholder: null,
+          },
+          stages: [],
         },
-        data() {
-            return {
-                error: null,
-                isDirty: false,
-                localStop: this.stopId,
-                showAlert: false,
-                newStageType: null,
-                stageTypes: {
-                    "separator": "Separator",
-                    "ar": "AR",
-                    "deepdives": "Deep Dives",
-                    "embed-frame": "Embed",
-                    "guide": "Guide",
-                    "gallery": "Gallery",
-                    "navigation": "Navigation",
-                    "quiz": "Quiz"
-                },
-                tour: null,
-                stop: {
-                    stop_content: {
-                        "title": {
-                             "placeholder": null
-                        },
-                        "stages": []
-                    }
-                },
-                stop_template: {
-                    stop_content: {
-                        "title": { 
-                             "placeholder": null
-                        },
-                        "stages": [{
-                                "text": {
-                                    "English": "Navigation"
-                                },
-                                "type": "separator"
-                            },
-                            {
-                                "text": {
-                                    "placeholder": null
-                                },
-                                "type": "navigation",
-                                "buttonTitle": {
-                                    "English": "Show Map"
-                                },
-                                "targetPoint": null
-                            },
-                            {
-                                "text": {
-                                    "English": "Guide"
-                                },
-                                "type": "separator"
-                            },
-                            {
-                                "text": {
-                                    "placeholder": null
-                                },
-                                "type": "guide"
-                            }
-                        ]
-                    }
-                }
-            }
-        },
-        computed: {
-            previewLink: function () {
-
-                return "/tour/" + this.tour.id + "/" + this.stop.sort_order;
-            }
-        },
-        watch: {
-            stop: {
-                handler: function(){
-                    this.isDirty = true;
-                },
-                deep: true
-            }
-        },
-        methods: {
-            addStage: function () {
-                this.stop.stop_content.stages.push({
-                    "type": this.newStageType
-                });
-                this.newStageType = null;
+      },
+      stop_template: {
+        stop_content: {
+          title: {
+            placeholder: null,
+          },
+          header_image: {
+            src: null,
+            alt: null,
+          },
+          stages: [
+            {
+              text: {
+                English: "Navigation",
+              },
+              type: "separator",
             },
-            save: function () {
-                if (!this.stop.id) {
-                    axios.post("/creator/edit/" + this.tour.id + "/stop/", this.stop)
-                        .then((res) => {
-                            this.isDirty = false;
-                            this.stop.id = res.data.id;
-                            this.loadTour();
-                            this.$router.replace({
-                                name: 'editStop',
-                                params: {
-                                    tourId: this.tourId,
-                                    stopId: this.stop.id
-                                }
-                            })
-                            this.showAlert = true;
-                            
-                        }).catch(res => {
-                            this.error = res;
-                        });
-                } else {
-                    axios.put("/creator/edit/" + this.tour.id + "/stop/" + this.stop.id, this.stop)
-                        .then((res) => {
-                            this.showAlert = true;
-                            this.isDirty = false;
-                        }).catch(res => {
-                            this.error = res;
-                        });
-                }
+            {
+              text: {
+                placeholder: null,
+              },
+              type: "navigation",
+              buttonTitle: {
+                English: "Show Map",
+              },
+              targetPoint: null,
             },
-            preventNav(event) {
-                if (!this.isDirty) return
-                event.preventDefault()
-                event.returnValue = ""
+            {
+              text: {
+                English: "Guide",
+              },
+              type: "separator",
             },
-            loadTour: function() {
-                // cache bust because otherwise we won't reload the tour when using the back button
-                axios.get("/creator/edit/" + this.tourId + "?" + Math.random())
-                    .then((res) => {
-                        this.tour = res.data
-                        if (this.stopId) {
-                            this.stop = this.tour.stops.find(s => s.id == this.stopId);
-                        } else if (this.tour.tour_content.use_template) {
-                            this.stop = this.stop_template;
-                        }
-                        this.$nextTick( () => {
-                            this.isDirty = false;
-                        })
-                        
-                    }).catch(res => {
-                        this.error = res;
-                    });
-                if(this.$can('administer site')) {
-                    this.stageTypes.language = "Language";
-                }
-            }
+            {
+              text: {
+                placeholder: null,
+              },
+              type: "guide",
+            },
+          ],
         },
-        mounted: function () {
+      },
+    };
+  },
+  computed: {
+    previewLink: function () {
+      return "/tour/" + this.tour.id + "/" + this.stop.sort_order;
+    },
+  },
+  watch: {
+    stop: {
+      handler: function () {
+        this.isDirty = true;
+      },
+      deep: true,
+    },
+  },
+  methods: {
+    addStage: function () {
+      this.stop.stop_content.stages.push({
+        type: this.newStageType,
+      });
+      this.newStageType = null;
+    },
+    save: function () {
+      if (!this.stop.id) {
+        axios
+          .post("/creator/edit/" + this.tour.id + "/stop/", this.stop)
+          .then((res) => {
+            this.isDirty = false;
+            this.stop.id = res.data.id;
             this.loadTour();
+            this.$router.replace({
+              name: "editStop",
+              params: {
+                tourId: this.tourId,
+                stopId: this.stop.id,
+              },
+            });
+            this.showAlert = true;
+          })
+          .catch((res) => {
+            this.error = res;
+          });
+      } else {
+        axios
+          .put(
+            "/creator/edit/" + this.tour.id + "/stop/" + this.stop.id,
+            this.stop
+          )
+          .then((res) => {
+            this.showAlert = true;
+            this.isDirty = false;
+          })
+          .catch((res) => {
+            this.error = res;
+          });
+      }
+    },
+    preventNav(event) {
+      if (!this.isDirty) return;
+      event.preventDefault();
+      event.returnValue = "";
+    },
+    migrateOldStopContent() {
+      if (!get(this.stop, "stop_content.header_image")) {
+        this.stop.stop_content.header_image =
+          this.stop_template.stop_content.header_image;
+      }
+    },
+    loadTour: function () {
+      // cache bust because otherwise we won't reload the tour when using the back button
+      axios
+        .get("/creator/edit/" + this.tourId + "?" + Math.random())
+        .then((res) => {
+          this.tour = res.data;
+          if (this.stopId) {
+            this.stop = this.tour.stops.find((s) => s.id == this.stopId);
+          } else if (this.tour.tour_content.use_template) {
+            this.stop = this.stop_template;
+          }
 
-        },
-        beforeMount() {
-            window.addEventListener("beforeunload", this.preventNav)
-            this.$once("hook:beforeDestroy", () => {
-                window.removeEventListener("beforeunload", this.preventNav);
-            })
-        },
-        beforeRouteLeave(to, from, next) {
-            if (this.isDirty) {
-                if (!window.confirm("Leave without saving?")) {
-                    return;
-                }
-            }
-            next();
-        }
+          // make sure that any new props are added to the stop_content json
+          this.migrateOldStopContent();
 
-        // created: function() {
-        //     if(!this.stop.title) {
-        //         Vue.set(this.stop, "title", {});
-        //         Vue.set(this.stop, "stages", []);
-        //     }
-        // }
+          this.$nextTick(() => {
+            this.isDirty = false;
+          });
+        })
+        .catch((res) => {
+          this.error = res;
+        });
+      if (this.$can("administer site")) {
+        this.stageTypes.language = "Language";
+      }
+    },
+  },
+  mounted: function () {
+    this.loadTour();
+  },
+  beforeMount() {
+    window.addEventListener("beforeunload", this.preventNav);
+    this.$once("hook:beforeDestroy", () => {
+      window.removeEventListener("beforeunload", this.preventNav);
+    });
+  },
+  beforeRouteLeave(to, from, next) {
+    if (this.isDirty) {
+      if (!window.confirm("Leave without saving?")) {
+        return;
+      }
     }
+    next();
+  },
+};
 </script>

--- a/resources/sass/edit.scss
+++ b/resources/sass/edit.scss
@@ -31,3 +31,8 @@ body {
   /* Vertically center the text there */
   background-color: #f5f5f5;
 }
+
+img {
+  max-width: 100%;
+  display: block;
+}


### PR DESCRIPTION
- Adds fields for including a url for a stop header image. I imagine we can add support for file upload or maybe unsplash searches later, but this is good enough for testing with Camino Trekker for now.

- Also adds laravel-cors config to project. I thought it was in Laravel by default, but maybe not in this version. camino-trekker is using https, but laravel sail isn't set up for https (yet)... There's probably a better approach, but 🤷 .
