### PR TITLE
set request headers when forwarding via proxy

### DIFF
--- a/docker/nginx/templates/default.conf.template
+++ b/docker/nginx/templates/default.conf.template
@@ -10,5 +10,17 @@ server {
 
   location / {
     proxy_pass	http://camino-laravel.test-1;
+    proxy_http_version  1.1;
+    proxy_cache_bypass  $http_upgrade;
+
+    proxy_set_header Upgrade           $http_upgrade;
+    proxy_set_header Connection        "upgrade";
+    proxy_set_header Host              $host;
+    proxy_set_header X-Real-IP         $remote_addr;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host  $host;
+    proxy_set_header X-Forwarded-Port  $server_port;
+
   }
 }


### PR DESCRIPTION
After setting up Nginx in front of Laravel Sail to support HTTPS in development environment (to support web apis that require a secure context), urls in the app (Camino) don't use the host name `localhost` and instead use the service name `camino-laravel.test-1`.

For example, (locally) Camino's shibboleth login page uses the url: `http://camino-laravel.test-1/shiblogin` but we want it to use: `https://localhost/shiblogin`.

This PR sets the `Host` header in nginx's proxy_pass block.

[This article](https://linuxize.com/post/nginx-reverse-proxy/#common-nginx-reverse-proxy-options) recommended a few others headers for reverse proxies using https, which are included.