### PR TITLE
fix image upload component

### DIFF
--- a/resources/js/components/edit/Edit.vue
+++ b/resources/js/components/edit/Edit.vue
@@ -119,7 +119,9 @@
             <div v-if="tour.tour_content.custom_base_map.use_basemap">
 
                 <image-upload v-if="!tour.tour_content.custom_base_map.image"
-                    v-on:imageuploaded="imageUploaded($event)"></image-upload>
+                    :imageSrc="tour.tour_content.custom_base_map.image"
+                    @imageuploaded="imageUploaded($event)" 
+                />
                 <div class="row">
                     <div class="form-group col-sm-2">
                         <label for="upper-left-latitude">Upper Left Latitude</label>

--- a/resources/js/components/edit/Gallery.vue
+++ b/resources/js/components/edit/Gallery.vue
@@ -1,7 +1,10 @@
 <template>
     <div>
         <div v-for="(image,key) in stage.images" :key="key" class="border rounded p-2 m-2">
-            <image-upload v-if="!image.src" v-on:imageuploaded="imageUploaded(key, $event)"></image-upload>
+            <image-upload v-if="!image.src" 
+                @imageuploaded="imageUploaded(key, $event)"
+                :imageSrc="image.src"
+            />
             <button @click="removeImage(image, key)" class="btn btn-outline-danger float-right" v-if="image.src"><i class="fas fa-trash"></i> Remove Image</button>
             <img :src="'/storage/' + image.src" class="img-thumbnail mb-2" v-if="image.src" width="200">
                     <language-text :text="image.text" :languages="languages" :largetext="false">
@@ -34,9 +37,6 @@
                         this.stage.images.splice(key, 1);
                     });
                 }
-
-                
-
             }
         }
     }

--- a/resources/js/components/edit/ImageUpload.vue
+++ b/resources/js/components/edit/ImageUpload.vue
@@ -1,75 +1,86 @@
 <template>
-    <div>
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-body">
-                    <div class="row">
-                        <div class="col-md-3 fa-3x" v-if="image">
-                            <i class="fas fa-spinner fa-spin"></i>
-                        </div>
-                        <div class="col">
-                            <div class="input-group mb-3">
-                                <div class="custom-file">
-                                    <input type="file" ref="file" v-on:change="onImageChange" class="custom-file-input"
-                                        id="inputGroupFile02" @change="uploadImage">
-                                    <label class="custom-file-label" for="inputGroupFile02"
-                                        aria-describedby="inputGroupFileAddon02">Choose an image</label>
-                                </div>
-                                <!-- <div class="input-group-append">
+  <div>
+    <div class="col-md-8">
+      <div class="card">
+        <div class="card-body">
+          <div class="row">
+            <div class="col-md-3 fa-3x" v-if="image">
+              <i class="fas fa-spinner fa-spin"></i>
+            </div>
+            <div class="col">
+              <div class="input-group mb-3">
+                <div class="custom-file">
+                  <input
+                    type="file"
+                    ref="file"
+                    v-on:change="onImageChange"
+                    class="custom-file-input"
+                    id="inputGroupFile02"
+                    @change="uploadImage"
+                  />
+                  <label
+                    class="custom-file-label"
+                    for="inputGroupFile02"
+                    aria-describedby="inputGroupFileAddon02"
+                    >Choose an image</label
+                  >
+                </div>
+                <!-- <div class="input-group-append">
                                     <button class="btn btn-outline-success" id="inputGroupFileAddon02" @click="uploadImage">Upload</button>
                                 </div> -->
-                            </div>
-                        </div>
-
-                    </div>
-                   <div class="row alert alert-danger mt-2" role="alert" v-if="errorText">
-                        <strong>Error: </strong> {{ errorText }}
-                    </div>
-                </div>
-                 
+              </div>
             </div>
+          </div>
+          <div
+            class="row alert alert-danger mt-2"
+            role="alert"
+            v-if="errorText"
+          >
+            <strong>Error: </strong> {{ errorText }}
+          </div>
         </div>
+      </div>
     </div>
+  </div>
 </template>
 
 <script>
-    export default {
-        data() {
-            return {
-                image: '',
-                errorText: null
-            }
-        },
-        methods: {
-            onImageChange(e) {
-                let files = e.target.files || e.dataTransfer.files;
-                if (!files.length)
-                    return;
-                this.createImage(files[0]);
-            },
-            createImage(file) {
-                let reader = new FileReader();
-                let vm = this;
-                reader.onload = (e) => {
-                    vm.image = e.target.result;
-                };
-                reader.readAsDataURL(file);
-            },
-            uploadImage() {
-                let data = new FormData()
-                this.errorText = null;
-                data.append('image', this.$refs.file.files[0])
-                axios.post('/creator/image/store', data).then(response => {
-                    if (response.data.success) {
-                        this.$emit("imageuploaded", response.data.image);    
-                        
-                    }
-                })
-                .catch((error) => {
-
-                    this.errorText = error.response.data.error.image;
-                });
-            }
-        }
-    }
+export default {
+  data() {
+    return {
+      image: "",
+      errorText: null,
+    };
+  },
+  methods: {
+    onImageChange(e) {
+      let files = e.target.files || e.dataTransfer.files;
+      if (!files.length) return;
+      this.createImage(files[0]);
+    },
+    createImage(file) {
+      let reader = new FileReader();
+      let vm = this;
+      reader.onload = (e) => {
+        vm.image = e.target.result;
+      };
+      reader.readAsDataURL(file);
+    },
+    uploadImage() {
+      let data = new FormData();
+      this.errorText = null;
+      data.append("image", this.$refs.file.files[0]);
+      axios
+        .post("/creator/image/store", data)
+        .then((response) => {
+          if (response.data.success) {
+            this.$emit("imageuploaded", response.data.image);
+          }
+        })
+        .catch((error) => {
+          this.errorText = error.response.data.error.image;
+        });
+    },
+  },
+};
 </script>

--- a/resources/js/components/edit/ImageUpload.vue
+++ b/resources/js/components/edit/ImageUpload.vue
@@ -1,43 +1,44 @@
 <template>
-  <div>
-    <div class="col-md-8">
-      <div class="card">
-        <div class="card-body">
-          <div class="row">
-            <div class="col-md-3 fa-3x" v-if="image">
-              <i class="fas fa-spinner fa-spin"></i>
-            </div>
-            <div class="col">
-              <div class="input-group mb-3">
-                <div class="custom-file">
-                  <input
-                    type="file"
-                    ref="file"
-                    v-on:change="onImageChange"
-                    class="custom-file-input"
-                    id="inputGroupFile02"
-                    @change="uploadImage"
-                  />
-                  <label
-                    class="custom-file-label"
-                    for="inputGroupFile02"
-                    aria-describedby="inputGroupFileAddon02"
-                    >Choose an image</label
-                  >
-                </div>
-                <!-- <div class="input-group-append">
-                                    <button class="btn btn-outline-success" id="inputGroupFileAddon02" @click="uploadImage">Upload</button>
-                                </div> -->
-              </div>
-            </div>
-          </div>
-          <div
-            class="row alert alert-danger mt-2"
-            role="alert"
-            v-if="errorText"
-          >
-            <strong>Error: </strong> {{ errorText }}
-          </div>
+  <div
+    class="image-upload"
+    :class="{
+      'image-upload--has-image': imageSrc,
+    }"
+  >
+    <label class="image-upload__label" for="image-upload-file">
+      Choose an image
+    </label>
+
+    <div
+      v-if="errorText"
+      class="image-upload__error alert alert-danger"
+      role="alert"
+    >
+      <strong>Error:</strong>
+      {{ errorText }}
+    </div>
+    <div class="image-upload__dropbox">
+      <img
+        v-if="imageSrc"
+        class="image-upload__preview"
+        :src="imageSrc"
+        alt="Image uploaded to server"
+      />
+      <input
+        type="file"
+        class="image-upload__input"
+        @change="onFileChange"
+        id="image-upload-file"
+        accept="image/gif, image/png, image/jpeg, image/webp"
+      />
+
+      <div class="image-upload__status">
+        <p v-if="!isUploading">
+          Drag your image here to {{ imageSrc ? "replace" : "upload" }} <br />
+          or click to browse
+        </p>
+        <div class="image-upload__spinner" v-if="isUploading">
+          <i class="fas fa-spinner fa-spin fa-3x"></i>
         </div>
       </div>
     </div>
@@ -46,41 +47,102 @@
 
 <script>
 export default {
+  props: {
+    imageSrc: {
+      type: String,
+      default: null,
+    },
+  },
   data() {
     return {
-      image: "",
+      isUploading: false,
       errorText: null,
     };
   },
   methods: {
-    onImageChange(e) {
-      let files = e.target.files || e.dataTransfer.files;
-      if (!files.length) return;
-      this.createImage(files[0]);
-    },
-    createImage(file) {
-      let reader = new FileReader();
-      let vm = this;
-      reader.onload = (e) => {
-        vm.image = e.target.result;
-      };
-      reader.readAsDataURL(file);
-    },
-    uploadImage() {
-      let data = new FormData();
+    onFileChange(e) {
+      const selectedFile = e.target.files[0];
       this.errorText = null;
-      data.append("image", this.$refs.file.files[0]);
+      this.isUploading = true;
+
+      const formData = new FormData();
+      formData.append("image", selectedFile);
+
       axios
-        .post("/creator/image/store", data)
+        .post("/creator/image/store", formData)
         .then((response) => {
-          if (response.data.success) {
-            this.$emit("imageuploaded", response.data.image);
+          this.isUploading = false;
+          if (!response.data.success) {
+            console.error(`Error: ${response.data.message}`);
+            this.errorText = response.data.message;
+            return;
           }
+
+          // this.imageUrl = `/storage/${response.data.image}`;
+          // console.log({ image: response.data.image });
+          this.$emit("imageuploaded", response.data.image);
         })
         .catch((error) => {
-          this.errorText = error.response.data.error.image;
+          console.error({ error });
+          this.errorText = error.message;
+          this.isUploading = false;
         });
     },
   },
 };
 </script>
+<style scoped>
+.image-upload__preview {
+  max-width: 400px;
+  max-height: 400px;
+  position: relative;
+  z-index: -1;
+}
+
+.image-upload__dropbox {
+  outline: 2px dashed grey; /* the dash box */
+  outline-offset: -10px;
+  background: hsla(0, 0%, 0%, 0.05);
+  color: #333;
+  padding: 10px 10px;
+  min-height: 200px; /* minimum height */
+  position: relative;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+
+.image-upload__input {
+  opacity: 0; /* invisible but it's there! */
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 10;
+}
+
+.image-upload__status {
+  font-size: 1.5rem;
+}
+
+.image-upload--has-image .image-upload__status {
+  display: none;
+}
+
+.image-upload--has-image .image-upload__dropbox:hover .image-upload__status {
+  display: block;
+  position: absolute;
+  z-index: 2;
+}
+
+.image-upload__dropbox:hover {
+  background: hsla(0, 0%, 0%, 0.5);
+  outline: 2px dashed #fff;
+  color: #fff;
+}
+</style>

--- a/resources/js/components/edit/TourStop.vue
+++ b/resources/js/components/edit/TourStop.vue
@@ -18,11 +18,11 @@
           >
             Stop Title
           </language-text>
-
           <image-upload
-            v-if="!stop.stop_content.header_image.src"
+           :imageSrc="headerImageSrc"
             @imageuploaded="handleImageUpload"
-          ></image-upload>
+            class="mb-4"
+          />
           <button
             @click="removeHeaderImage"
             class="btn btn-outline-danger float-right"
@@ -30,12 +30,6 @@
           >
             <i class="fas fa-trash"></i> Remove Image
           </button>
-          <img
-            v-if="stop.stop_content.header_image.src"
-            :src="'/storage/' + stop.stop_content.header_image.src"
-            class="img-thumbnail mb-2"
-            width="200"
-          />
           <div class="form-group row">
             <label class="col-sm-2 col-form-label" for="header-image-alt">
               Image Alt
@@ -205,6 +199,9 @@ export default {
     previewLink: function () {
       return "/tour/" + this.tour.id + "/" + this.stop.sort_order;
     },
+    headerImageSrc() {
+      return get(this.stop, "stop_content.header_image.src");
+    },
   },
   watch: {
     stop: {
@@ -222,11 +219,7 @@ export default {
       this.newStageType = null;
     },
     handleImageUpload(imgSrc) {
-      const image = this.stop.stop_content.header_image;
-      this.stop.stop_content.header_image = {
-        src: imgSrc,
-        alt: image.alt || "",
-      };
+      this.stop.stop_content.header_image.src = `/storage/${imgSrc}`;
     },
     removeHeaderImage: function () {
       const image = this.stop.stop_content.header_image;
@@ -289,6 +282,7 @@ export default {
       }
     },
     loadTour: function () {
+      console.log('loadTour');
       // cache bust because otherwise we won't reload the tour when using the back button
       axios
         .get("/creator/edit/" + this.tourId + "?" + Math.random())

--- a/resources/js/components/edit/TourStop.vue
+++ b/resources/js/components/edit/TourStop.vue
@@ -19,7 +19,7 @@
             Stop Title
           </language-text>
           <image-upload
-           :imageSrc="headerImageSrc"
+            :imageSrc="headerImageSrc"
             @imageuploaded="handleImageUpload"
             class="mb-4"
           />
@@ -282,7 +282,6 @@ export default {
       }
     },
     loadTour: function () {
-      console.log('loadTour');
       // cache bust because otherwise we won't reload the tour when using the back button
       axios
         .get("/creator/edit/" + this.tourId + "?" + Math.random())


### PR DESCRIPTION
Image upload on the tour stop can sometimes be a bit flakey. This seemed to be caused by two problems:
1. Multiple onchange handlers on the file input
2. on image upload setting `stop.stop_content.header_image` to be an object, which didn't seem to trigger a rerender with updated image source. (I'm not exactly sure why this happens)

This PR:
- refactors the `<ImageUpload>` component, removing the extra change handler, and a bit of dead code.
- imageupload also handles previewing the current image at the `imageSrc` prop.
- changes the design to be similar to the chimein dropbox design (let's users drag and drop or click for upload)

No image:
<img width="600" alt="Screen Shot 2022-02-16 at 1 40 12 PM" src="https://user-images.githubusercontent.com/980170/154343084-083f3d32-84af-4c9b-a6af-e407da59028f.png">

With image:
<img width="600" alt="Screen Shot 2022-02-16 at 1 39 54 PM" src="https://user-images.githubusercontent.com/980170/154343134-b602b07e-38c4-40ea-93a7-8f90e3adca4e.png">

Hovering over image to replace:
<img width="600" alt="Screen Shot 2022-02-16 at 1 43 14 PM" src="https://user-images.githubusercontent.com/980170/154343454-7ce878c8-12b9-4299-b161-de63d706a568.png">



