### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,28 +33,11 @@ sail artisan migrate:fresh --seed
 npm ci
 
 # Start Laravel Mix to compile Vue
-npm run watch
+npm run hot
 
 ```
 
-The application will be running on <http://localhost>.
-
-Login to create a user. To promote to administrator:
-
-```sh
-sail tinker
-```
-
-Then:
-
-```php
-\App\User::find(1)->assignRole("administrator");
-```
-
-Note:
-
-- The seeded default tour is a tour template.
-- The tour map will be gray until a new tour is created.
+The application will be running on <https://localhost>.
 
 ## Using the Application
 


### PR DESCRIPTION
Updates Readme to align with seeder changes:

- change `http` to `https`
- Remove instructions to manually assign admin role, since this is now assigned by user seeder