### PR TITLE
Add support for import aliases in place of long relative paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "sass-loader": "^13.0.0",
         "sass-resources-loader": "^2.2.5",
         "ts-loader": "^9.3.0",
+        "tsconfig-paths-webpack-plugin": "^3.5.2",
         "typescript": "^4.7.2",
         "vue-loader": "^17.0.0"
       }
@@ -2344,6 +2345,12 @@
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
+    },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true
     },
     "node_modules/@types/mime": {
       "version": "1.3.2",
@@ -11441,6 +11448,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -11814,6 +11830,41 @@
       "peerDependencies": {
         "typescript": "*",
         "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
+      "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-3.5.2.tgz",
+      "integrity": "sha512-EhnfjHbzm5IYI9YPNVIxx1moxMI4bpHD2e0zTXeDNQcwjjRaGepP7IhTHJkyDBG0CAOoxRfe7jCG630Ou+C6Pw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.7.0",
+        "tsconfig-paths": "^3.9.0"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/json5": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
       }
     },
     "node_modules/tslib": {
@@ -14621,6 +14672,12 @@
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
+    },
+    "@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true
     },
     "@types/mime": {
       "version": "1.3.2",
@@ -21576,6 +21633,12 @@
         "ansi-regex": "^5.0.1"
       }
     },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
+    },
     "strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -21836,6 +21899,40 @@
         "enhanced-resolve": "^5.0.0",
         "micromatch": "^4.0.0",
         "semver": "^7.3.4"
+      }
+    },
+    "tsconfig-paths": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
+      "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
+      "dev": true,
+      "requires": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        }
+      }
+    },
+    "tsconfig-paths-webpack-plugin": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-3.5.2.tgz",
+      "integrity": "sha512-EhnfjHbzm5IYI9YPNVIxx1moxMI4bpHD2e0zTXeDNQcwjjRaGepP7IhTHJkyDBG0CAOoxRfe7jCG630Ou+C6Pw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.7.0",
+        "tsconfig-paths": "^3.9.0"
       }
     },
     "tslib": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "sass-loader": "^13.0.0",
     "sass-resources-loader": "^2.2.5",
     "ts-loader": "^9.3.0",
+    "tsconfig-paths-webpack-plugin": "^3.5.2",
     "typescript": "^4.7.2",
     "vue-loader": "^17.0.0"
   },

--- a/resources/camino-trekker/components/Stage/Stage.vue
+++ b/resources/camino-trekker/components/Stage/Stage.vue
@@ -5,7 +5,7 @@
     <pre>{{ stage }}</pre>
   </div>
 </template>
-<script setup>
+<script setup lang="ts">
 import { computed } from "vue";
 import LanguageSelect from "./stages/LanguageSelect.vue";
 import Guide from "./stages/Guide.vue";
@@ -17,18 +17,20 @@ import EmbedFrame from "./stages/EmbedFrame.vue";
 import DeepDives from "./stages/DeepDives.vue";
 import Feedback from "./stages/Feedback.vue";
 import DeepDivesSummary from "./stages/DeepDivesSummary.vue";
+import { StageType } from "@/types";
+import type { Component } from "vue";
 
-const componentLookup = {
-  ar: AR,
-  "embed-frame": EmbedFrame,
-  deepdives: DeepDives,
-  "deepdives-summary": DeepDivesSummary,
-  feedback: Feedback,
-  gallery: Gallery,
-  guide: Guide,
-  language: LanguageSelect,
-  navigation: Navigation,
-  separator: Separator,
+const componentLookup: Partial<{ [stageKey in StageType]: Component }> = {
+  [StageType.AR]: AR,
+  [StageType.EmbedFrame]: EmbedFrame,
+  [StageType.DeepDives]: DeepDives,
+  [StageType.DeepDivesSummary]: DeepDivesSummary,
+  [StageType.Feedback]: Feedback,
+  [StageType.Gallery]: Gallery,
+  [StageType.Guide]: Guide,
+  [StageType.LanguageSelector]: LanguageSelect,
+  [StageType.Navigation]: Navigation,
+  [StageType.Separator]: Separator,
 };
 
 const props = defineProps({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,14 @@
     "jsx": "preserve",
     "moduleResolution": "node",
     "noImplicitAny": false,
-    "allowJs": true
+    "allowJs": true,
+    "baseUrl": "resources",
+    // this enables the use of `import` statements in TypeScript files
+    // like `import { Component } from '@/components';
+    // requires `tsconfig-paths-webpack-plugin` in order to work
+    // with webpack's `alias` feature
+    "paths": {
+      "@/*": ["*"]
+    }
   }
 }

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const mix = require("laravel-mix");
+const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin");
 
 // Main Laravel App Styles and Scripts (homepage)
 mix
@@ -47,6 +48,13 @@ if (mix.inProduction()) {
           key: fs.readFileSync("./.cert/key.pem"),
           cert: fs.readFileSync("./.cert/cert.pem"),
         },
+      },
+      // uses for resolving aliases like "@/trekker/components"
+      // instead of using long relative paths
+      // See tsconfig.json `paths` to set up aliases
+      resolve: {
+        plugins: [new TsconfigPathsPlugin({})],
+        extensions: [".ts", ".js", ".vue"],
       },
     });
 }


### PR DESCRIPTION
Accessing the `types` file can require lengthy relative paths for imports:
` import type { StageType } from '../../../../types'`

Webpack aliases are a common solution to these 
`import type { StageType } from '@/types'`

This adds Typescript-friendly support for aliases, and lets us have a single source of truth using the `paths` prop in tsconfig by using [tsconfig-paths-webpack-plugin](https://www.npmjs.com/package/tsconfig-paths-webpack-plugin).

It also changes the ComponentLookup table to use the StageType enum. (Which I used to test that '@/types' was compiling as expected, and still let me use type completion.)