### PR TITLE
Fix TS build errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "watch": "mix watch",
     "watch-poll": "mix watch -- --watch-options-poll=1000",
     "hot": "mix watch --hot",
+    "prod": "npm run production",
     "production": "mix --production",
     "docs:dev": "vuepress dev docs",
     "docs:build": "vuepress build docs",

--- a/resources/camino-trekker/components/Stage/stages/DeepDivesSummary.vue
+++ b/resources/camino-trekker/components/Stage/stages/DeepDivesSummary.vue
@@ -20,8 +20,8 @@
       >
         <DeepDivesSummaryItem
           :id="`deepdive-${key}`"
-          :title="deepdive.title[locale]"
-          :content="deepdive.text[locale]"
+          :title="getTextForLocale(deepdive.title, locale, '')"
+          :content="getTextForLocale(deepdive.text, locale, '')"
           :checked="isDeepDiveChecked(deepdive)"
           :checkboxHidden="!stage.request_email"
           @toggleChecked="(isChecked) => setChecked(deepdive, isChecked)"
@@ -52,7 +52,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, ref, type Ref } from "vue";
 import axios from "axios";
 import { useTour, useLocale } from "@trekker/common/hooks";
 import Markdown from "../../Markdown/Markdown.vue";
@@ -63,7 +63,8 @@ import Button from "../../Button/Button.vue";
 import Input from "../../Input/Input.vue";
 import config from "../../../config";
 import { useTrekkerStore } from "@/camino-trekker/stores/useTrekkerStore";
-import { DeepDiveItem, DeepDiveSummaryStage } from "@/types";
+import getTextForLocale from "@/camino-trekker/utils/getTextForLocale";
+import type { DeepDiveItem, DeepDiveSummaryStage } from "@/types";
 
 interface Props {
   stage: DeepDiveSummaryStage;
@@ -78,10 +79,12 @@ const email = ref("");
 const isSendingEmail = ref(false);
 const isSent = ref(false);
 const error = ref("");
-// const success = ref(false);
-const deepDiveSummaryText = computed(() => props.stage.text[locale.value]);
+
+const deepDiveSummaryText = computed(
+  () => props.stage.text[locale.value] || ""
+);
 const checkedDeepDives = computed(() => store.deepDives);
-const allDeepDives = computed(() => {
+const allDeepDives: Ref<DeepDiveItem[]> = computed(() => {
   const deepDiveStages = getStagesFromTourWhere(
     "type",
     "deepdives",

--- a/resources/camino-trekker/components/Stage/stages/DeepDivesSummary.vue
+++ b/resources/camino-trekker/components/Stage/stages/DeepDivesSummary.vue
@@ -52,7 +52,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, type Ref } from "vue";
+import { computed, ref } from "vue";
 import axios from "axios";
 import { useTour, useLocale } from "@trekker/common/hooks";
 import Markdown from "../../Markdown/Markdown.vue";
@@ -64,7 +64,11 @@ import Input from "../../Input/Input.vue";
 import config from "../../../config";
 import { useTrekkerStore } from "@/camino-trekker/stores/useTrekkerStore";
 import getTextForLocale from "@/camino-trekker/utils/getTextForLocale";
-import type { DeepDiveItem, DeepDiveSummaryStage } from "@/types";
+import type {
+  DeepDiveItem,
+  DeepDiveSummaryStage,
+  DeepDiveStage,
+} from "@/types";
 
 interface Props {
   stage: DeepDiveSummaryStage;
@@ -84,8 +88,9 @@ const deepDiveSummaryText = computed(
   () => props.stage.text[locale.value] || ""
 );
 const checkedDeepDives = computed(() => store.deepDives);
-const allDeepDives: Ref<DeepDiveItem[]> = computed(() => {
-  const deepDiveStages = getStagesFromTourWhere(
+const allDeepDives = computed(() => {
+  if (!tour.value) return [];
+  const deepDiveStages = getStagesFromTourWhere<DeepDiveStage>(
     "type",
     "deepdives",
     tour.value

--- a/resources/camino-trekker/components/Stage/stages/DeepDivesSummaryItem.vue
+++ b/resources/camino-trekker/components/Stage/stages/DeepDivesSummaryItem.vue
@@ -32,34 +32,28 @@
     </div>
   </div>
 </template>
-<script setup>
+<script setup lang="ts">
 import Markdown from "../../Markdown/Markdown.vue";
 import { ref } from "vue";
 
-defineProps({
-  id: {
-    type: String,
-    required: true,
-  },
-  title: {
-    type: String,
-    required: true,
-  },
-  content: {
-    type: String,
-    required: true,
-  },
-  checked: {
-    type: Boolean,
-    default: false,
-  },
-  checkboxHidden: {
-    type: Boolean,
-    default: false,
-  },
+interface Props {
+  id: string;
+  title: string;
+  content: string;
+  checked?: boolean;
+  checkboxHidden?: boolean;
+}
+
+withDefaults(defineProps<Props>(), {
+  checked: false,
+  checkboxHidden: false,
 });
 
-defineEmits(["toggleChecked"]);
+interface Emits {
+  (eventValue: "toggleChecked", isChecked: boolean): void;
+}
+
+defineEmits<Emits>();
 
 const showDetails = ref(false);
 

--- a/resources/camino-trekker/utils/getStagesFromStopWhere.js
+++ b/resources/camino-trekker/utils/getStagesFromStopWhere.js
@@ -1,5 +1,0 @@
-export default (stageKey, stageValue, stop) => {
-  return stop.stop_content.stages.filter(
-    (stage) => stage[stageKey] === stageValue
-  );
-};

--- a/resources/camino-trekker/utils/getStagesFromStopWhere.ts
+++ b/resources/camino-trekker/utils/getStagesFromStopWhere.ts
@@ -1,0 +1,10 @@
+import type { TourStop, Stage } from "@/types";
+
+export default <T extends Stage>(
+  stageKey: string,
+  stageValue: T[keyof T],
+  stop: TourStop
+): T[] => {
+  const stages = stop.stop_content.stages as T[];
+  return stages.filter((stage) => stage[stageKey] === stageValue);
+};

--- a/resources/camino-trekker/utils/getStagesFromTourWhere.js
+++ b/resources/camino-trekker/utils/getStagesFromTourWhere.js
@@ -1,6 +1,0 @@
-import getStagesFromStopWhere from "./getStagesFromStopWhere";
-
-export default (stageKey, stageValue, tour) =>
-  tour.stops.flatMap((stop) =>
-    getStagesFromStopWhere(stageKey, stageValue, stop)
-  );

--- a/resources/camino-trekker/utils/getStagesFromTourWhere.ts
+++ b/resources/camino-trekker/utils/getStagesFromTourWhere.ts
@@ -1,0 +1,11 @@
+import { Stage, Tour } from "@/types";
+import getStagesFromStopWhere from "./getStagesFromStopWhere";
+
+export default <T extends Stage>(
+  stageKey: string,
+  stageValue: T[keyof T],
+  tour: Tour
+): T[] =>
+  tour.stops.flatMap((stop) =>
+    getStagesFromStopWhere<T>(stageKey, stageValue, stop)
+  );

--- a/resources/camino-trekker/utils/getTextForLocale.ts
+++ b/resources/camino-trekker/utils/getTextForLocale.ts
@@ -1,0 +1,23 @@
+import type { LocalizedText, Locale, Maybe } from "@/types";
+
+export default function getTextForLocale(
+  localizedTextObj: LocalizedText,
+  locale: Locale,
+  fallback?: string
+): string {
+  const text: Maybe<string> = localizedTextObj[locale] ?? null;
+
+  if (text !== null) {
+    return text;
+  }
+
+  // using typeof rather than !fallback in case
+  // fallback is ""
+  if (typeof fallback === "string") {
+    return fallback;
+  }
+
+  throw new Error(
+    `no localized text found for locale ${locale} in ${localizedTextObj}. Consider setting a fallback.`
+  );
+}

--- a/resources/types.ts
+++ b/resources/types.ts
@@ -92,7 +92,7 @@ export interface Waypoint {
   location: LngLat;
 }
 
-export interface Stage {
+export interface Stage extends Record<string, any> {
   id: UUID;
   type: StageType;
 }

--- a/resources/types.ts
+++ b/resources/types.ts
@@ -27,7 +27,7 @@ export interface LngLat {
 }
 
 export type LocalizedText = {
-  [localeKey in Locale]: string;
+  [localeKey in Locale]?: string;
 };
 
 export interface ARWaypoint {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,5 +19,6 @@
       "@creator/*": ["camino-creator/*"]
     },
     "sourceMap": true
-  }
+  },
+  "exclude": ["node_modules", "**/*.stories.js"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,5 @@
     },
     "sourceMap": true
   },
-  "exclude": ["node_modules", "**/*.stories.js"]
+  "exclude": ["node_modules", "*.stories.*"]
 }

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -20,13 +20,26 @@ mix
   .ts("resources/camino-creator/app.ts", "public/js/camino-creator.js")
   .sass("resources/camino-creator/main.scss", "public/css/camino-creator.css");
 
-mix.vue({
-  options: {
-    compilerOptions: {
-      isCustomElement: (tag) => ["a-text", "a-scene", "a-camera"].includes(tag),
+// All apps: both production and development
+mix
+  .vue({
+    options: {
+      compilerOptions: {
+        isCustomElement: (tag) =>
+          ["a-text", "a-scene", "a-camera"].includes(tag),
+      },
     },
-  },
-});
+  })
+  .sourceMaps()
+  .webpackConfig({
+    // uses for resolving aliases like "@/trekker/components"
+    // instead of using long relative paths
+    // See tsconfig.json `paths` to set up aliases
+    resolve: {
+      plugins: [new TsconfigPathsPlugin({})],
+      extensions: [".ts", ".js", ".vue"],
+    },
+  });
 
 if (mix.inProduction()) {
   mix.version();
@@ -46,13 +59,6 @@ if (mix.inProduction()) {
           key: fs.readFileSync("./.cert/key.pem"),
           cert: fs.readFileSync("./.cert/cert.pem"),
         },
-      },
-      // uses for resolving aliases like "@/trekker/components"
-      // instead of using long relative paths
-      // See tsconfig.json `paths` to set up aliases
-      resolve: {
-        plugins: [new TsconfigPathsPlugin({})],
-        extensions: [".ts", ".js", ".vue"],
       },
     });
 }


### PR DESCRIPTION
Fixes some ts build errors that would occur when deploying or running `npm run production`.

### Webpack aliases
Webpack aliases like `@/types` were not working because the paths resolver plugin was only set to run when building for dev. `webpack.mix.js` is updated so that the plugin loads in the production build step.

### Error: Implicit conversion of a 'symbol' to a 'string' will fail at runtime. 

Production build would produce errors like:
```
 TS2731: Implicit conversion of a 'symbol' to a 'string' will fail at runtime. Consider wrapping this expression in 'String(...)'.
```

This converted some of the files and components imported into DeepDivesSummary.vue from js to ts and added explicit types.

### Also

Added `npm run prod` as an alias for `npm run production` because typing is hard (for some of us).
