### PR TITLE
explicitly cast v-for index as number

### DIFF
--- a/resources/camino-creator/components/Stage/stages/DeepDives.vue
+++ b/resources/camino-creator/components/Stage/stages/DeepDives.vue
@@ -5,7 +5,7 @@
         :text="deepdive.title"
         :languages="languages"
         :largetext="false"
-        @update:text="(title) => updateDeepDive(index, { title })"
+        @update:text="(title) => updateDeepDive(index as number, { title })"
       >
         Deep Dive Title
       </LanguageText>
@@ -13,14 +13,14 @@
         :text="deepdive.text"
         :languages="languages"
         :largetext="true"
-        @update:text="(text) => updateDeepDive(index, { text })"
+        @update:text="(text) => updateDeepDive(index as number, { text })"
       >
         Deep Dive Text
       </LanguageText>
       <button
         v-if="deepdive.title"
         class="btn btn-outline-danger float-right"
-        @click="removeDeepDive(index)"
+        @click="removeDeepDive(index as number)"
       >
         <i class="fas fa-trash"></i> Remove Deep Dive
       </button>


### PR DESCRIPTION
This one is tricky.

Again, when building `npm run production`, ts emits an error:

```
ERROR in /Users/johnsojr/code/Camino/resources/camino-creator/components/Stage/stages/DeepDives.vue.ts
112:53-58
[tsl] ERROR in /Users/johnsojr/code/Camino/resources/camino-creator/components/Stage/stages/DeepDives.vue.ts(112,54)
      TS2345: Argument of type 'string | number | symbol' is not assignable to parameter of type 'number'.
  Type 'string' is not assignable to type 'number'.
```

This is unhelpful for several reasons:

1. the error references line **112**, but the `DeepDives.vue` file has **less than 100 lines**, so presumably this is the line number after some transpiling step. 😒
2. the error doesn't show up in VSCode (or WebStorm for that matter) with Vetur or ESlint  😖
3. The error doesn't happen when building for `dev` - only `production` 😡

Ultimately, I traced the error to the `index` value in the `v-for` statement.

Hovering over the index variable in VSCode, shows a `number` type. But it seems that TS  has trouble typing this when building for production.

Explicitly declaring `index as number` when used in the v-for loop makes the issue go away.

One hypothesis is that `v-for` can be used on objects AND arrays, so the index could be a `string` or a `symbol` (if object) or number (if array). And maybe some transpiling step for production throws away the necessary context to distinguish whether this is an object or an array.

I suspect the issue may crop up again with v-for indices when building for production, so it might be best to always explicitly declare the index type with v-for loops. (Maybe there's some way to add a linting rule for this?)

This PR explicitly types index in the deepdives component.