### PR TITLE
Reintroduce drag-and-drop reordering to tour stops

### DIFF
--- a/resources/camino-creator/components/LanguageText.vue
+++ b/resources/camino-creator/components/LanguageText.vue
@@ -34,7 +34,7 @@
               type="text"
               class="form-control"
               :value="text[language]"
-              @input="handleTextUpdate(language, $event.target.value)"
+              @input="handleTextUpdate(language, ($event.target as HTMLInputElement).value)"
             />
           </div>
           <div class="col-sm-4">
@@ -45,34 +45,26 @@
     </template>
   </div>
 </template>
-<script setup>
+<script setup lang="ts">
 import MarkdownEditor from "./MarkdownEditor.vue";
+import { Locale, LocalizedText } from "@/types";
+import t from "@/shared/t";
 
-const props = defineProps({
-  languages: {
-    type: Array,
-    required: true,
-  },
-  // FIXME: text is actually a localized text object of the form
-  // { 'en': 'Hello', 'es': 'Hola' }
-  // currently it's not using two-letter locale codes.
-  text: {
-    type: Object,
-    required: true,
-  },
-  // FIXME: unclear that this is a boolean to turn this into a textarea in
-  // perhaps just make a separate textare component?
-  largetext: {
-    type: Boolean,
-    default: false,
-  },
+interface Props {
+  languages: Locale[];
+  text: LocalizedText;
+  largetext: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  largetext: false,
 });
 
 const emit = defineEmits(["update:text"]);
 
 const randomIdentifier = Math.round(Math.random() * 10000).toString();
 
-function handleTextUpdate(language, updatedText) {
+function handleTextUpdate(language: Locale, updatedText: string) {
   const updatedTextObj = {
     ...props.text,
     [language]: updatedText,

--- a/resources/camino-creator/components/LanguageText.vue
+++ b/resources/camino-creator/components/LanguageText.vue
@@ -12,7 +12,7 @@
           </label>
           <MarkdownEditor
             v-if="largetext"
-            :modelValue="text[language]"
+            :modelValue="t(text, language)"
             @update:modelValue="
               (payload) => handleTextUpdate(language, payload)
             "

--- a/resources/camino-creator/components/LanguageText.vue
+++ b/resources/camino-creator/components/LanguageText.vue
@@ -53,7 +53,7 @@ import t from "@/shared/t";
 interface Props {
   languages: Locale[];
   text: LocalizedText;
-  largetext: boolean;
+  largetext?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {

--- a/resources/camino-creator/main.scss
+++ b/resources/camino-creator/main.scss
@@ -25,3 +25,8 @@ a {
 a:hover:not(.btn) {
   text-decoration: underline;
 }
+
+/* Move Handle */
+.handle {
+  cursor: move;
+}

--- a/resources/camino-creator/pages/EditPage/EditPage.vue
+++ b/resources/camino-creator/pages/EditPage/EditPage.vue
@@ -178,10 +178,6 @@ async function save() {
 </script>
 
 <style scoped>
-.handle {
-  cursor: move;
-}
-
 .col-form-label {
   font-weight: bold;
 }

--- a/resources/camino-creator/pages/EditPage/TourStopCard.vue
+++ b/resources/camino-creator/pages/EditPage/TourStopCard.vue
@@ -1,0 +1,61 @@
+<template>
+  <div class="card mt-2">
+    <div class="card-body d-flex justify-content-between align-items-center">
+      <h4 class="card-title">
+        <i v-if="showMoveHandle" class="fas fa-grip-vertical handle"></i>
+        <router-link
+          :to="{
+            name: 'editStop',
+            params: { tourId, stopId: stop.id },
+          }"
+        >
+          {{ stop.stop_content.title[locale] }}
+        </router-link>
+      </h4>
+      <div class="controls d-flex gap-1">
+        <button class="btn btn-outline-danger" @click="handleDeleteStopClick">
+          <i class="fas fa-trash"></i> Delete
+        </button>
+
+        <a
+          :href="`/trekker/tours/${tourId}/stops/${stop.sort_order}`"
+          class="btn btn-outline-success"
+          target="_blank"
+          ><i class="fas fa-eye"></i>
+          <span class="d-none d-sm-inline">Preview</span>
+        </a>
+        <router-link
+          :to="{
+            name: 'editStop',
+            params: { tourId, stopId: stop.id },
+          }"
+          class="btn btn-outline-primary"
+          ><i class="fas fa-edit"></i>
+          <span class="d-none d-sm-inline">Edit</span></router-link
+        >
+      </div>
+    </div>
+  </div>
+</template>
+<script setup lang="ts">
+import type { TourStop } from "@/types";
+import { useCreatorStore } from "@creator/stores/useCreatorStore";
+
+interface Props {
+  tourId: number;
+  stop: TourStop;
+  showMoveHandle?: boolean;
+}
+const props = withDefaults(defineProps<Props>(), {
+  showMoveHandle: true,
+});
+
+const creatorStore = useCreatorStore();
+const locale = creatorStore.getDefaultTourLanguage(props.tourId);
+
+function handleDeleteStopClick(stopId) {
+  if (confirm("Are you sure you wish to delete this stop?")) {
+    creatorStore.deleteTourStop(props.tourId, stopId);
+  }
+}
+</script>

--- a/resources/camino-creator/pages/EditPage/TourStopList.vue
+++ b/resources/camino-creator/pages/EditPage/TourStopList.vue
@@ -51,9 +51,6 @@
       </Draggable>
       <TourStopCard :tourId="tourId" :stop="lastStop" :showMoveHandle="false" />
     </div>
-    <!-- <draggable v-model="tour.stops" :move="checkMove" handle=".handle"> -->
-
-    <!-- </draggable> -->
   </section>
 </template>
 <script setup lang="ts">

--- a/resources/camino-creator/pages/EditPage/TourStopList.vue
+++ b/resources/camino-creator/pages/EditPage/TourStopList.vue
@@ -27,70 +27,52 @@
       </form>
     </header>
 
-    <!-- <draggable v-model="tour.stops" :move="checkMove" handle=".handle"> -->
-    <div
-      v-for="stop in creatorStore.getTour(tourId).stops"
-      :key="stop.id"
-      class="card mt-2"
-    >
-      <div class="card-body d-flex justify-content-between align-items-center">
-        <h4 class="card-title">
-          <i v-if="!isLockedItem(stop)" class="fas fa-grip-vertical handle"></i>
-          <router-link
-            :to="{
-              name: 'editStop',
-              params: { tourId, stopId: stop.id },
-            }"
-          >
-            {{ stop.stop_content.title[locale] }}
-          </router-link>
-        </h4>
-        <div class="controls d-flex gap-1">
-          <button class="btn btn-outline-danger" @click="deleteStop(stop.id)">
-            <i class="fas fa-trash"></i> Delete
-          </button>
-
-          <a
-            :href="`/trekker/tours/${tourId}/stops/${stop.sort_order}`"
-            class="btn btn-outline-success"
-            target="_blank"
-            ><i class="fas fa-eye"></i>
-            <span class="d-none d-sm-inline">Preview</span>
-          </a>
-          <router-link
-            :to="{
-              name: 'editStop',
-              params: { tourId, stopId: stop.id },
-            }"
-            class="btn btn-outline-primary"
-            ><i class="fas fa-edit"></i>
-            <span class="d-none d-sm-inline">Edit</span></router-link
-          >
-        </div>
-      </div>
+    <div class="stop-list">
+      <TourStopCard
+        :tourId="tourId"
+        :stop="firstStop"
+        :showMoveHandle="false"
+      />
+      <Draggable
+        :modelValue="moveableStops"
+        itemKey="id"
+        class="stop-list__movable-stops"
+        handle=".handle"
+        ghostClass="ghost"
+        @change="handleTourStopMove"
+      >
+        <template #item="{ element }">
+          <TourStopCard
+            :tourId="tourId"
+            :stop="element"
+            :showMoveHandle="true"
+          />
+        </template>
+      </Draggable>
+      <TourStopCard :tourId="tourId" :stop="lastStop" :showMoveHandle="false" />
     </div>
+    <!-- <draggable v-model="tour.stops" :move="checkMove" handle=".handle"> -->
+
     <!-- </draggable> -->
   </section>
 </template>
-<script setup>
-import { ref } from "vue";
+<script setup lang="ts">
+import { ref, computed, nextTick } from "vue";
 import { useCreatorStore } from "@creator/stores/useCreatorStore";
 import LanguageText from "../../components/LanguageText.vue";
 import { createMultilingualText } from "../../components/Stage/stages/stageFactory";
+import TourStopCard from "./TourStopCard.vue";
+import { Locale, type TourStop } from "@/types";
+import Draggable from "vuedraggable";
 
-const props = defineProps({
-  tourId: {
-    type: Number,
-    required: true,
-  },
-  stops: {
-    type: Array,
-    required: true,
-  },
-  locale: {
-    type: String,
-    default: "English",
-  },
+interface Props {
+  tourId: number;
+  stops: TourStop[];
+  locale: Locale;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  locale: Locale.en,
 });
 
 const creatorStore = useCreatorStore();
@@ -101,26 +83,36 @@ const languages = creatorStore.getTourLanguages(props.tourId);
 const newTitle = ref(createMultilingualText(languages));
 
 function createNew() {
-  creatorStore.createTourStop(props.tourId, {
-    stop_content: {
-      title: newTitle.value,
-    },
-  });
+  creatorStore.createTourStop(props.tourId, newTitle.value);
   showCreateForm.value = false;
   newTitle.value = createMultilingualText(languages);
 }
 
-function isLockedItem(stop) {
-  return (
-    stop.sort_order === 0 ||
-    stop.sort_order ===
-      props.stops.map((s) => s.sort_order).reduce((a, b) => Math.max(a, b))
-  );
-}
+const tourStops = computed<TourStop[]>(
+  () => creatorStore.getTour(props.tourId).stops
+);
 
-function deleteStop(stopId) {
-  if (confirm("Are you sure you wish to delete this stop?")) {
-    creatorStore.deleteTourStop(props.tourId, stopId);
-  }
+const firstStop = computed<TourStop>(() => tourStops.value[0]);
+const lastStop = computed<TourStop>(
+  () => tourStops.value[tourStops.value.length - 1]
+);
+const moveableStops = computed<TourStop[]>(() =>
+  tourStops.value.filter(
+    (s) => s.id !== firstStop.value.id && s.id !== lastStop.value.id
+  )
+);
+
+const draggableKey = ref(0);
+function handleTourStopMove(event) {
+  if (!event.moved) return;
+  const { oldIndex, newIndex } = event.moved;
+
+  // old and new indices are from the movable stops
+  // array and don't account for the the static first
+  // stop. So, we need to shift the indices by 1;
+  creatorStore.moveTourStopByIndex(props.tourId, oldIndex + 1, newIndex + 1);
+
+  // force rerender
+  nextTick(() => (draggableKey.value += 1));
 }
 </script>

--- a/resources/camino-creator/stores/useCreatorStore.ts
+++ b/resources/camino-creator/stores/useCreatorStore.ts
@@ -4,7 +4,7 @@ import { mergeDeepRight, insert, move } from "ramda";
 import { defineStore, acceptHMRUpdate } from "pinia";
 import createDefaultStop from "../common/createDefaultStop";
 import createDefaultTour from "../common/createDefaultTour";
-import { Tour, Maybe, TourStop, Locale } from "@/types";
+import { Tour, Maybe, TourStop, Locale, LocalizedText } from "@/types";
 import { axiosClient as axios } from "@creator/common/axios";
 
 const route = useRoute();
@@ -151,8 +151,15 @@ export const useCreatorStore = defineStore("creator", {
       this.fetchTours();
     },
 
-    async createTourStop(tourId: number, stop: TourStop): Promise<TourStop> {
-      const newStop = mergeDeepRight(createDefaultStop(), stop);
+    async createTourStop(
+      tourId: number,
+      stopTitle: LocalizedText
+    ): Promise<TourStop> {
+      const newStop = mergeDeepRight(createDefaultStop(), {
+        stop_content: {
+          title: stopTitle,
+        },
+      });
 
       // optimistic update
       const tourIndex = this.getTourIndex(tourId);

--- a/resources/camino-trekker/components/Stage/stages/DeepDivesSummary.vue
+++ b/resources/camino-trekker/components/Stage/stages/DeepDivesSummary.vue
@@ -20,8 +20,8 @@
       >
         <DeepDivesSummaryItem
           :id="`deepdive-${key}`"
-          :title="getTextForLocale(deepdive.title, locale, '')"
-          :content="getTextForLocale(deepdive.text, locale, '')"
+          :title="t(deepdive.title, locale, '')"
+          :content="t(deepdive.text, locale, '')"
           :checked="isDeepDiveChecked(deepdive)"
           :checkboxHidden="!stage.request_email"
           @toggleChecked="(isChecked) => setChecked(deepdive, isChecked)"
@@ -63,7 +63,7 @@ import Button from "../../Button/Button.vue";
 import Input from "../../Input/Input.vue";
 import config from "../../../config";
 import { useTrekkerStore } from "@/camino-trekker/stores/useTrekkerStore";
-import getTextForLocale from "@/camino-trekker/utils/getTextForLocale";
+import t from "@/shared/t";
 import type {
   DeepDiveItem,
   DeepDiveSummaryStage,

--- a/resources/shared/t.ts
+++ b/resources/shared/t.ts
@@ -1,9 +1,14 @@
 import type { LocalizedText, Locale, Maybe } from "@/types";
 
-export default function getTextForLocale(
+/**
+ * Given a localized text object and a locale, gets
+ * the correct text string.
+ */
+
+export default function getTranslation(
   localizedTextObj: LocalizedText,
   locale: Locale,
-  fallback?: string
+  defaultValue?: string
 ): string {
   const text: Maybe<string> = localizedTextObj[locale] ?? null;
 
@@ -13,8 +18,8 @@ export default function getTextForLocale(
 
   // using typeof rather than !fallback in case
   // fallback is ""
-  if (typeof fallback === "string") {
-    return fallback;
+  if (typeof defaultValue === "string") {
+    return defaultValue;
   }
 
   throw new Error(

--- a/resources/types.ts
+++ b/resources/types.ts
@@ -1,3 +1,5 @@
+import { useCreatorStore } from "@creator/stores/useCreatorStore";
+
 export type Maybe<T> = T | null;
 
 /**
@@ -129,7 +131,7 @@ export interface GalleryStage extends Stage {
 export interface GuideStage extends Stage {
   text: LocalizedText;
 }
-export interface LanguageSelectorStage extends Stage {}
+export type LanguageSelectorStage = Stage;
 export interface NavigationStage extends Stage {
   text: LocalizedText;
   route: LngLat[];
@@ -150,7 +152,7 @@ export interface QuizStage extends Stage {
   hintText: LocalizedText;
   responses: QuizChoice[];
 }
-export interface SeparatorStage extends Stage {}
+export type SeparatorStage = Stage;
 
 export type URL = Brand<string, "URL">;
 
@@ -243,3 +245,5 @@ export interface FeedbackResponse {
   created_at: DateTime;
   feedback: string;
 }
+
+export type CreatorStore = ReturnType<typeof useCreatorStore>;


### PR DESCRIPTION
In update to Vue3, we disabled draggable reordering of tour stops until we could factor the prop mutation into state updates via pinia. Now that the dust has settled, we can update the Draggable library for Vue3, and reintroduce it to the app.

This PR:
- Updates Draggable lib
- Uses their new api (which I hate if anyone's keeping score), to add drag-and-drop to reordering to Tour Stops
- Extracts tour stop cards to separate components
- Adds pinia actions for reordering
- updates other pinia actions so that they optimistically update the UI, and then rollback if a change failed for some reason
- converts some things to TS along the way

Reintroducing Stage drag and drop will happen in a separate PR.