### PR TITLE
Handle case where localized text object might be null or undefined.

### DIFF
--- a/resources/shared/i18n.ts
+++ b/resources/shared/i18n.ts
@@ -6,11 +6,11 @@ import { Locale, type LocalizedText, type Maybe } from "@/types";
  */
 
 export const getLocalizedText = (
-  localizedTextObj: LocalizedText,
+  localizedTextObj: Maybe<LocalizedText>,
   locale: Locale,
   defaultValue = ""
 ): string => {
-  const text: Maybe<string> = localizedTextObj[locale] ?? null;
+  const text: Maybe<string> = localizedTextObj?.[locale] ?? null;
   return text !== null ? text : defaultValue;
 };
 
@@ -19,7 +19,7 @@ export const translate = getLocalizedText;
 export const setLocalizedText = (
   locale: Locale,
   text: string,
-  localizedTextObj = {} as LocalizedText
+  localizedTextObj: Maybe<LocalizedText> = {}
 ): LocalizedText => ({
   ...localizedTextObj,
   [locale]: text,


### PR DESCRIPTION
When new fields are added to an object (e.g. TourStop added `subtitle`), it's possible that no localized text object exists yet, causes a blank section.

This changes `getLocalizedText` to handle the case where localized object might be `null` / `undefined`, and return `defaultValue` (empty string).