### PR TITLE
Fix CI by adding a chown after laravel setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,14 +42,14 @@ jobs:
       - name: Install JS dependencies
         run: yarn && yarn prod
 
-      - name: Set ownership
-        run: |
-          docker compose exec -T laravel.test chown -R $WWWUSER:$WWWGROUP storage
-
       - name: Laravel Setup
         run: |
           docker compose exec -T laravel.test ./bin/ci.sh
           docker compose exec -T laravel.test php artisan migrate:fresh --seed
+
+      - name: Set ownership
+        run: |
+          docker compose exec -T laravel.test chown -R $WWWUSER:$WWWGROUP storage
 
       # - name: Lint code
       #   run: yarn lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Set ownership
         run: |
-          docker compose exec -T laravel.test chown -R 1000:1000 storage
+          docker compose exec -T laravel.test chown -R $WWWUSER:$WWWGROUP storage
 
       # - name: Lint code
       #   run: yarn lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,14 +42,14 @@ jobs:
       - name: Install JS dependencies
         run: yarn && yarn prod
 
-      - name: Set ownership
-        run: |
-          docker compose exec -T laravel.test chown -R ${{ env.WWWUSER }}:${{ env.WWWGROUP }} .
-
       - name: Laravel Setup
         run: |
           docker compose exec -T laravel.test ./bin/ci.sh
           docker compose exec -T laravel.test php artisan migrate:fresh --seed
+
+      - name: Set ownership
+        run: |
+          docker compose exec -T laravel.test chown -R ${{ env.WWWUSER }}:${{ env.WWWGROUP }} .
 
       # - name: Lint code
       #   run: yarn lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,13 @@ jobs:
       - name: Install JS dependencies
         run: yarn && yarn prod
 
+      - name: Set ownership
+        run: |
+          docker compose exec -T laravel.test chown -R ${{ env.WWWUSER }}:${{ env.WWWGROUP }} .
+
       - name: Laravel Setup
         run: |
           docker compose exec -T laravel.test ./bin/ci.sh
-          docker compose exec -T laravel.test chown -R 1000:1000 storage
           docker compose exec -T laravel.test php artisan migrate:fresh --seed
 
       # - name: Lint code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Set ownership
         run: |
-          docker compose exec -T laravel.test chown -R ${{ env.WWWUSER }}:${{ env.WWWGROUP }} .
+          docker compose exec -T laravel.test chown -R 1000:1000 storage
 
       # - name: Lint code
       #   run: yarn lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,14 +42,14 @@ jobs:
       - name: Install JS dependencies
         run: yarn && yarn prod
 
+      - name: Set ownership
+        run: |
+          docker compose exec -T laravel.test chown -R $WWWUSER:$WWWGROUP storage
+
       - name: Laravel Setup
         run: |
           docker compose exec -T laravel.test ./bin/ci.sh
           docker compose exec -T laravel.test php artisan migrate:fresh --seed
-
-      - name: Set ownership
-        run: |
-          docker compose exec -T laravel.test chown -R $WWWUSER:$WWWGROUP storage
 
       # - name: Lint code
       #   run: yarn lint


### PR DESCRIPTION
Adds a `chown -R $WWWUSER:$WWWGROUP storage` after all the Laravel setup to make sure everything is owned by the wwwuser.