### PR TITLE
fix(creator): :bug: add scrollBehavior to createRouter

### DIFF
--- a/resources/camino-creator/router.ts
+++ b/resources/camino-creator/router.ts
@@ -52,6 +52,13 @@ const routes = [
 const router = createRouter({
   history: createWebHistory(),
   routes,
+  scrollBehavior(to, from, savedPosition) {
+    if (savedPosition) {
+      return savedPosition;
+    } else {
+      return { top: 0 };
+    }
+  },
 });
 
 export default router;


### PR DESCRIPTION
This adds native-like scrolling behavior when navigating between routes in vue router. Previously, when routing from one page to the next, the page would remain at the same  scroll position.

Closes #117