### PR TITLE
Change deployment to use `yarn` and resolve subtitle migration issue

### DIFF
--- a/database/migrations/2022_06_03_192302_add_subtitle_to_stop.php
+++ b/database/migrations/2022_06_03_192302_add_subtitle_to_stop.php
@@ -20,8 +20,12 @@ return new class extends Migration
                     return;
                 }
 
-                // set a default null on subtitle
-                $stop->stop_content->subtitle = NULL;
+                // update stop_content json, changing stop_content.subtitle to 
+                // null
+                $stop->stop_content = [
+                    ...$stop->stop_content,
+                    'subtitle' => NULL
+                ];
                 $stop->save();
             });
         });

--- a/deploy.php
+++ b/deploy.php
@@ -3,7 +3,7 @@
 namespace Deployer;
 
 require 'recipe/laravel.php';
-require 'contrib/npm.php';
+require 'contrib/yarn.php';
 
 // Configuration
 set('ssh_type', 'native');
@@ -45,7 +45,7 @@ host('prod')
 
 task('assets:generate', function () {
     cd('{{release_path}}');
-    run('npm run production');
+    run('yarn production');
 })->desc('Assets generation');
 
 task('fix_storage_perms', function () {
@@ -61,5 +61,5 @@ after('deploy:failed', 'deploy:unlock');
 
 // Migrate database before symlink new release.
 before('deploy:symlink', 'artisan:migrate');
-after('deploy:update_code', 'npm:install');
+after('deploy:update_code', 'yarn:install');
 after('deploy:shared', 'assets:generate');


### PR DESCRIPTION
- Change from `npm` to `yarn`

In deploying, the migration to add `subtitle` prop to `stop_content` threw an error (same error as before):
```
Indirect modification of overloaded property App\Stop::$stop_content has no effect
```

I'm not sure why ` $stop->stop_content->subtitle = NULL;` doesn't work, but I returned to the approach where I spread existing props and overwrite `subtitle`:

```php
                $stop->stop_content = [
                    ...$stop->stop_content,
                    'subtitle' => NULL
                ];
```

@cmcfadden – if you know why the original throws an error, I'd be curious. (I thought it should work with the magic methods in laravel). Not a big deal though...
