### PR TITLE
Stage clean up

### DIFF
--- a/resources/camino-creator/components/LngLatDisplay.vue
+++ b/resources/camino-creator/components/LngLatDisplay.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="d-inline-flex gap-4 my-2 bg-light p-2">
+  <div class="d-inline-flex gap-4 p-2">
     <div>
       <small class="d-block">Latitude</small>
       <span data-cy="location-lat">{{

--- a/resources/camino-creator/components/MapboxLocationSelector.vue
+++ b/resources/camino-creator/components/MapboxLocationSelector.vue
@@ -45,7 +45,10 @@
     <Alert v-if="geolocationError" class="my-2" variant="warning">
       {{ geolocationError.message }}
     </Alert>
-    <div class="route-mapper__button-group d-flex justify-content-end mt-3">
+    <div
+      class="route-mapper__button-group d-flex justify-content-between px-2 py-1 align-items-center"
+    >
+      <LngLatDisplay :coord="location" />
       <BButton @click="handleUseCurrentLocation">Use Current Location</BButton>
     </div>
   </div>
@@ -64,6 +67,7 @@ import BButton from "./BButton.vue";
 import { useGeolocation } from "@vueuse/core";
 import Alert from "./Alert.vue";
 import { UMN_LNGLAT } from "@/shared/constants";
+import LngLatDisplay from "./LngLatDisplay.vue";
 
 const props = withDefaults(
   defineProps<{

--- a/resources/camino-creator/components/NavStageRouteMapper.vue
+++ b/resources/camino-creator/components/NavStageRouteMapper.vue
@@ -77,7 +77,7 @@
     <Alert v-if="geolocationError" class="my-2" variant="warning">
       {{ geolocationError.message }}
     </Alert>
-    <div class="route-mapper__button-group d-flex justify-content-end mt-3">
+    <div class="route-mapper__button-group d-flex justify-content-end p-3">
       <BButton variant="tertiary" @click="$emit('update:route', [])"
         >Clear Route</BButton
       >
@@ -91,12 +91,7 @@
 <script setup lang="ts">
 import { ref, computed, nextTick } from "vue";
 import useConfig from "@/shared/useConfig";
-import {
-  Map as MapboxMap,
-  // MapLayerEventType,
-  // MapLayerMouseEvent,
-  // MapMouseEvent,
-} from "mapbox-gl";
+import { Map as MapboxMap } from "mapbox-gl";
 import { LngLat, Maybe, TourStopRoute } from "@/types";
 import { useCreatorStore } from "@creator/stores/useCreatorStore";
 import Map from "@trekker/components/Map/Map.vue";
@@ -139,15 +134,7 @@ const offsetPointFromLastTarget = computed(
   (): LngLat => getOffsetPointFrom(lastValuedTargetPoint.value)
 );
 
-/**
- * always returns some target point
- * - props.targetPoint, then
- * - last stop's target point offset by a bit
- */
 const currentValuedTargetPoint = computed((): LngLat => {
-  // use current passed target point
-  // which may be different from the store's target point
-  // if we haven't saved yet
   return props.targetPoint ?? offsetPointFromLastTarget.value;
 });
 
@@ -205,44 +192,8 @@ const routeToNextRoute = computed((): Maybe<TourStopRoute> => {
   return routeToRoute;
 });
 
-// function onMapEvent(
-//   map: MapboxMap,
-//   eventName: keyof MapLayerEventType,
-//   handlerFn: (event: MapLayerMouseEvent) => void,
-//   options: { ignoreLayerId: string }
-// ) {
-//   // set up a handler to ignore the layer with the given layer id
-//   if (options.ignoreLayerId) {
-//     map.on(eventName, options.ignoreLayerId, (event) => {
-//       event.originalEvent.preventDefault();
-//     });
-//   }
-
-//   // now we can check if default was prevented on our event
-//   // before running the given handler function
-//   map.on("click", (event) => {
-//     if (event.originalEvent.defaultPrevented) return;
-//     handlerFn(event);
-//   });
-// }
-
 function handleMapLoad(map: MapboxMap) {
   mapRef.value = map;
-
-  // listen for click events to update the target point,
-  // but ignore events that happen on the "gl-draw-polygon-midpoint.cold"
-  // layer, since that those clicks will on the midpoint to create a new
-  // waypoint on the route line
-  // onMapEvent(
-  //   map,
-  //   "click",
-  //   (event: MapMouseEvent) =>
-  //     emit("update:targetPoint", {
-  //       lng: event.lngLat.lng,
-  //       lat: event.lngLat.lat,
-  //     }),
-  //   { ignoreLayerId: "gl-draw-polygon-midpoint.cold" }
-  // );
 }
 
 function flyTo(lnglat: LngLat) {
@@ -288,7 +239,8 @@ function handleUseCurrentLocation() {
 }
 .route-mapper {
   background: #f3f3f3;
-  padding: 1rem;
-  border-radius: 0.25rem;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
 }
 </style>

--- a/resources/camino-creator/components/Stage/Stage.vue
+++ b/resources/camino-creator/components/Stage/Stage.vue
@@ -6,11 +6,9 @@
           <i class="fas fa-grip-vertical handle"></i> {{ stage.type }}
         </h5>
         <div class="controls">
-          <button
-            class="btn btn-outline-danger"
-            @click="$emit('remove', stage)"
-          >
-            <i class="fas fa-trash"></i> Remove Stage
+          <button class="stage__remove-button" @click="$emit('remove', stage)">
+            <i class="fas fa-times"></i>
+            <span class="sr-only">Remove Stage</span>
           </button>
         </div>
       </div>
@@ -80,5 +78,21 @@ const componentName = computed(() => componentLookup[props.stage.type]);
 .card-title {
   margin-bottom: 0px;
   text-transform: capitalize;
+}
+.stage__remove-button {
+  background: #f3f3f3;
+  border: none;
+  color: #777;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.stage__remove-button:hover {
+  background: #333;
+  color: #fff;
 }
 </style>

--- a/resources/camino-creator/components/Stage/stages/Navigation.vue
+++ b/resources/camino-creator/components/Stage/stages/Navigation.vue
@@ -9,7 +9,7 @@
       Navigation Text
     </LanguageText>
 
-    <section class="my-3">
+    <section class="mt-3">
       <NavStageRouteMapper
         :tourId="tourId"
         :stopId="stopId"

--- a/resources/camino-creator/pages/TourPage/InitialLocation.vue
+++ b/resources/camino-creator/pages/TourPage/InitialLocation.vue
@@ -1,8 +1,7 @@
 <template>
   <div class="form-group row my-4 initial-location">
     <label for="tourTitle" class="col-sm-2 col-form-label">Location</label>
-    <div class="col-sm-6 bg-white p-2 d-flex flex-column">
-      <LngLatDisplay :coord="modelValue" class="d-flex" />
+    <div class="col-sm-6 bg-white p-0 rounded-3 border overflow-hidden">
       <MapboxLocationSelector
         :location="modelValue"
         :tourId="tourId"
@@ -15,7 +14,6 @@
 <script setup lang="ts">
 import { CustomBaseMap, LngLat, Maybe } from "@/types";
 import MapboxLocationSelector from "../../components/MapboxLocationSelector.vue";
-import LngLatDisplay from "@/camino-creator/components/LngLatDisplay.vue";
 
 interface Props {
   tourId: number;


### PR DESCRIPTION
Moves the LngLat display below the map in the Location selector, in the whitespace opposite of the Use Current Location button:
<img width="500" alt="Screen Shot 2022-06-29 at 4 00 35 PM" src="https://user-images.githubusercontent.com/980170/176544225-d175daf6-8309-4768-8157-788f457b23d5.png">

- Changes the big red remove button for stages to a more subtle X:
<img width="500" alt="Screen Shot 2022-06-29 at 4 01 20 PM" src="https://user-images.githubusercontent.com/980170/176544246-b035f134-d09d-4c0e-a33c-2525429f140a.png">

- Removes some dead code in the NavStageRouteMapper