### PR TITLE
Fix: find first valued target point by stop id  – not index – in MapBoxLocationSelector

### DIFF
--- a/resources/camino-creator/components/MapboxLocationSelector.vue
+++ b/resources/camino-creator/components/MapboxLocationSelector.vue
@@ -98,7 +98,7 @@ const currentValuedLocation = computed((): LngLat => {
   if (props.location) return props.location;
 
   const nextStartPoint: Maybe<LngLat> = props.tourId
-    ? store.getNextTourStopStartPoint(props.tourId, 0).value
+    ? store.findFirstValuedTargetPoint(props.tourId).value
     : null;
 
   if (nextStartPoint) return getOffsetPointFrom(nextStartPoint);

--- a/resources/camino-creator/stores/creatorStoreSelectors.ts
+++ b/resources/camino-creator/stores/creatorStoreSelectors.ts
@@ -329,3 +329,17 @@ export const findValuedTargetPoint = (
     return DEFAULT_TARGET_POINT;
   }
 };
+
+export const findFirstValuedTargetPoint = (currentState, tourId): LngLat => {
+  const tour = selectTour(currentState, tourId);
+
+  if (tour.start_location) return tour.start_location;
+
+  // get a list of all non-null target points
+  const targetPoints = tour.stops
+    .map((stop) => selectTourStopTargetPoint(currentState, tourId, stop.id))
+    .filter(Boolean) as LngLat[];
+
+  // return the first or the default point
+  return targetPoints.length ? targetPoints[0] : UMN_LNGLAT;
+};

--- a/resources/camino-creator/stores/useCreatorStore.ts
+++ b/resources/camino-creator/stores/useCreatorStore.ts
@@ -84,6 +84,8 @@ export const useCreatorStore = defineStore("creator", () => {
       computed(() =>
         selectors.selectNextTourStopStartPoint(state, tourId, stopId)
       ),
+    findFirstValuedTargetPoint: (tourId: number) =>
+      computed(() => selectors.findFirstValuedTargetPoint(state, tourId)),
     findValuedTargetPoint: (
       tourId: number | null | undefined,
       stopId: number | null | undefined


### PR DESCRIPTION
MapboxLocationSelector searches for the next valid start point if no location is set, but this could result in an error in the current implementation.

That is, in `store.getNextTourStopStartPoint(props.tourId, 0).value` the second parameter should be the stopId, not the index.

This PR adds a new store method to find the `findFirstValuedTargetPoint` given a tourId. The method returns the start_location or the first non-null target point (or a default point if neither exist).