### PR TITLE
fix issue where Camino Trekker shows selected locale for all options (e.g. "English" "English")

### DIFF
--- a/resources/camino-trekker/components/Stage/stages/PureLanguageSelect.vue
+++ b/resources/camino-trekker/components/Stage/stages/PureLanguageSelect.vue
@@ -18,7 +18,7 @@
           :checked="selectedLocale === localeChoice"
           @change="handleChange(localeChoice)"
         />
-        {{ locale }}
+        {{ localeChoice }}
       </label>
       <Button class="save-button" type="submit" variant="primary">Save</Button>
     </form>


### PR DESCRIPTION
This fixes the Language Select component in Camino Trekker. Previous it would show the selected locale for each option (e.g. "English" "English"), rather than the locale option ("English" "Espanol")