### PR TITLE
fix: handleAddStage

### DIFF
--- a/cypress/integration/creator/TourStopPage.spec.js
+++ b/cypress/integration/creator/TourStopPage.spec.js
@@ -43,7 +43,42 @@ describe("Tour Stop Page", () => {
   it("changes the stop image");
   it("removes a stop image");
   it("edits a separator stage title");
-  it("removes a stage");
-  it("adds a stage");
+  it("removes a stage", () => {
+    // check that guide stage is present
+    cy.get("[data-cy='stage-title']")
+      .contains("guide")
+      .should("exist")
+      // remove the guide stage
+      .parents(".tour-stop-stage")
+      .find('[data-cy="remove-stage-button"]')
+      .click();
+
+    // verify that the guide stage is gone
+    cy.get("[data-cy='stage-title']").contains("guide").should("not.exist");
+  });
+
+  it("adds a stage", () => {
+    // check that stages exists with default stages
+    cy.get('[data-cy="tour-stop-stages"]')
+      .should("contain.text", "Navigation")
+      .should("contain.text", "Guide");
+
+    // select a new stage
+    cy.get("[data-cy='select-stage-type']").select("AR");
+
+    // click add stage
+    cy.contains("Add a Stage").click();
+
+    // check that the stage is added to the stage list
+    cy.get(".tour-stop-stage:last-of-type .card-title").should(
+      "contain.text",
+      "ar"
+    );
+
+    // check that the stage content appears on the stop page
+    cy.contains("Save").click();
+    cy.contains("Preview").click();
+    cy.get(".ar-stage > .button").should("contain.text", "Look Around");
+  });
   it("adds a stop location via the navigation stage");
 });

--- a/resources/camino-creator/components/Stage/Stage.vue
+++ b/resources/camino-creator/components/Stage/Stage.vue
@@ -1,12 +1,16 @@
 <template>
-  <div class="card mt-2">
+  <div class="card mt-2 tour-stop-stage">
     <div class="card-body">
       <div class="d-flex justify-content-between align-items-center">
-        <h5 class="card-title">
+        <h5 class="card-title" data-cy="stage-title">
           <i class="fas fa-grip-vertical handle"></i> {{ stage.type }}
         </h5>
         <div class="controls">
-          <button class="stage__remove-button" @click="$emit('remove', stage)">
+          <button
+            class="stage__remove-button"
+            data-cy="remove-stage-button"
+            @click="$emit('remove', stage)"
+          >
             <i class="fas fa-times"></i>
             <span class="sr-only">Remove Stage</span>
           </button>

--- a/resources/camino-creator/pages/TourStopPage/TourStopPage.vue
+++ b/resources/camino-creator/pages/TourStopPage/TourStopPage.vue
@@ -271,7 +271,7 @@ function handleAddStage() {
   }
 
   const newStage = stageFactory.create(newStageType.value, {
-    languages: tourLanguages,
+    languages: tourLanguages.value,
   });
 
   stop.value.stop_content.stages.push(newStage);

--- a/resources/camino-creator/pages/TourStopPage/TourStopPage.vue
+++ b/resources/camino-creator/pages/TourStopPage/TourStopPage.vue
@@ -62,6 +62,7 @@
 
         <Draggable
           v-model="stop.stop_content.stages"
+          data-cy="tour-stop-stages"
           itemKey="id"
           handle=".handle"
           ghostClass="ghost"
@@ -116,6 +117,7 @@
           <div class="row d-flex justify-content-end">
             <select
               v-model="newStageType"
+              data-cy="select-stage-type"
               class="form-select"
               aria-label="Select a Stage"
             >


### PR DESCRIPTION
Fixes an error when adding a new stage: tourLanguages is a ref and needs a `.value`.

(I probably should turn off allowing implicit `any` types in TS, but that could be a lot of red squiggles to fix.)
