### PR TITLE
Refactor: Extract sanitization logic to separate `<SanitizeHTML>` component

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "docs:dev": "vuepress dev docs",
     "docs:build": "vuepress build docs",
     "cert": "rm -rf .cert && mkdir -p .cert && mkcert -key-file ./.cert/key.pem -cert-file ./.cert/cert.pem 'localhost' 127.0.0.1 `ipconfig getifaddr en0`",
-    "lint": "eslint './**/*.{js,mjs,cjs,vue,ts}'",
+    "lint": "eslint",
     "prettier:check": "prettier --check .",
     "prettier:write": "prettier --write .",
     "pretty-quick": "pretty-quick",

--- a/resources/camino-trekker/components/Markdown/Markdown.vue
+++ b/resources/camino-trekker/components/Markdown/Markdown.vue
@@ -1,24 +1,16 @@
 <template>
   <!-- eslint-disable vue/no-v-html -->
-  <div class="markdown" v-html="cleanHtml"></div>
+  <SanitizedHTML class="markdown" :html="marked.parse(content ?? '')" />
 </template>
 
 <script setup lang="ts">
 import { marked } from "marked";
-import { sanitize } from "dompurify";
-import { pipe } from "ramda";
-import { computed } from "vue";
 import type { Maybe } from "@/types";
+import SanitizedHTML from "../SanitizedHTML/SanitizedHTML.vue";
 
-interface Props {
+defineProps<{
   content: Maybe<string>;
-}
-
-const props = defineProps<Props>();
-
-// parse markdown, THEN sanitize the resulting HTML
-const toCleanHtml = pipe(marked.parse, sanitize);
-const cleanHtml = computed(() => toCleanHtml(props.content ?? ""));
+}>();
 </script>
 
 <style scoped>

--- a/resources/camino-trekker/components/SanitizedHTML/SanitizedHTML.vue
+++ b/resources/camino-trekker/components/SanitizedHTML/SanitizedHTML.vue
@@ -1,0 +1,14 @@
+<template>
+  <!-- eslint-disable-next-line vue/no-v-html -->
+  <div v-html="sanitizedHtml" />
+</template>
+<script setup lang="ts">
+import { sanitize } from "dompurify";
+import { computed } from "vue";
+
+const props = defineProps<{
+  html: string;
+}>();
+
+const sanitizedHtml = computed(() => sanitize(props.html));
+</script>

--- a/resources/js/components/DeepDivesSummary.vue
+++ b/resources/js/components/DeepDivesSummary.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="$store.getters.deepdives.length > 0">
-    <div v-html="formattedText"></div>
+    <SanitizedHTML :html="formattedText" />
 
     <div class="form-inline">
       <label for="email" class="sr-only">E-mail address</label>
@@ -33,7 +33,7 @@
     >
       <div class="card-body">
         <h5 class="card-title">{{ deepdive.title[$i18n.locale] }}</h5>
-        <p class="card-text" v-html="deepdive.text[$i18n.locale]"></p>
+        <SanitizedHTML class="card-text" :html="deepdive.text[$i18n.locale]" />
       </div>
     </div>
   </div>
@@ -44,8 +44,10 @@
 
 <script>
 import { useI18n } from "vue-i18n";
+import SanitizedHTML from "@/camino-trekker/components/SanitizedHTML/SanitizedHTML.vue";
 
 export default {
+  components: { SanitizedHTML },
   // eslint-disable-next-line vue/require-prop-types
   props: ["stage", "tour"],
   setup() {

--- a/resources/js/components/Feedback.vue
+++ b/resources/js/components/Feedback.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div v-html="formattedText"></div>
+    <SanitizedHTML :html="formattedText" />
 
     <BButton v-b-toggle.collapse-feedback variant="primary">{{
       t("stage.feedback.button")
@@ -54,8 +54,10 @@
 
 <script>
 import { useI18n } from "vue-i18n";
+import SanitizedHTML from "@/camino-trekker/components/SanitizedHTML/SanitizedHTML.vue";
 
 export default {
+  components: { SanitizedHTML },
   props: ["stage", "tour"],
   setup() {
     const { t } = useI18n(); // use as global scope


### PR DESCRIPTION
This creates a single component to handle html sanitization rather than using `v-html`  + sanitize logic.

Also, removes args from eslint script in package.json, which seemed to be slowing lint-staged in VScode.