### PR TITLE
Fix feedback form submission

### DIFF
--- a/resources/camino-trekker/components/Input/Input.vue
+++ b/resources/camino-trekker/components/Input/Input.vue
@@ -17,7 +17,14 @@
         Required
       </small>
     </div>
-    <input class="input-group__input" v-bind="$attrs" />
+    <input
+      class="input-group__input"
+      v-bind="$attrs"
+      :value="modelValue"
+      @input="
+        $emit('update:modelValue', ($event.target as HTMLInputElement).value)
+      "
+    />
     <small v-if="hint">
       {{ hint }}
     </small>
@@ -26,13 +33,19 @@
 <script setup lang="ts">
 import { useAttrs, computed } from "vue";
 
-interface Props {
-  label: string;
-  labelHidden: boolean;
-  hint: string;
-}
+withDefaults(
+  defineProps<{
+    label: string;
+    labelHidden?: boolean;
+    hint?: string;
+    modelValue: string;
+  }>(),
+  { labelHidden: false, hint: "", modelValue: "" }
+);
 
-withDefaults(defineProps<Props>(), { labelHidden: false, hint: "" });
+defineEmits<{
+  (eventName: "update:modelValue", value: string);
+}>();
 
 const attrs = useAttrs();
 

--- a/resources/camino-trekker/components/Stage/stages/Feedback.vue
+++ b/resources/camino-trekker/components/Stage/stages/Feedback.vue
@@ -37,11 +37,12 @@ function submitFeedback() {
       email: email.value,
       feedback: feedback.value,
     })
-    .then((response) => {
-      console.log({ response });
+    .then(() => {
       isSubmitting.value = false;
       isSuccessful.value = true;
-      email.value = "";
+
+      // reset comment, but keep name and email
+      feedback.value = "";
     })
     .catch((err) => {
       isSubmitting.value = false;

--- a/resources/camino-trekker/components/TextArea/TextArea.vue
+++ b/resources/camino-trekker/components/TextArea/TextArea.vue
@@ -11,7 +11,11 @@
         rows="4"
         class="textarea-group__input"
         v-bind="$attrs"
-      ></textarea>
+        :value="modelValue"
+        @input="
+          $emit('update:modelValue', ($event.target as HTMLInputElement).value)
+        "
+      />
       <small v-if="hint">
         {{ hint }}
       </small>
@@ -23,14 +27,19 @@ import { useAttrs, computed } from "vue";
 
 withDefaults(
   defineProps<{
+    modelValue: string;
     label: string;
     hint?: string;
   }>(),
   {
     hint: "",
+    modelValue: "",
   }
 );
 
+defineEmits<{
+  (eventName: "update:modelValue", value: string);
+}>();
 const attrs = useAttrs();
 
 const isRequired = computed(() => attrs.required !== undefined);


### PR DESCRIPTION
The `<Input>` and `<TextArea>` elements were not correctly using `v-model`, causing the feedback form to be submitted with empty data. 

This adds a `modelValue` prop, and an `update:modelValue` event to both (which is equivalent to vue3's v-model).

On successful feedback, the `comment` field is reset, but `name` and `email` remain.