### PR TITLE
fix: active routes or stops may not appear to the user

### DIFF
--- a/resources/camino-trekker/components/MapMarkerLabel/MapMarkerLabel.vue
+++ b/resources/camino-trekker/components/MapMarkerLabel/MapMarkerLabel.vue
@@ -13,11 +13,9 @@
   </div>
 </template>
 <script setup lang="ts">
-export type MapMarkerLabelColors = "pink" | "orange" | "default";
-
 withDefaults(
   defineProps<{
-    color?: MapMarkerLabelColors;
+    color?: "pink" | "orange" | "default";
     pulse?: boolean;
   }>(),
   {

--- a/resources/camino-trekker/components/MapMarkerLabel/MapMarkerLabel.vue
+++ b/resources/camino-trekker/components/MapMarkerLabel/MapMarkerLabel.vue
@@ -13,9 +13,12 @@
   </div>
 </template>
 <script setup lang="ts">
+// import { MapMarkerLabelColors } from "@/types";
+export type MapMarkerLabelColors = "pink" | "orange" | "default";
+
 withDefaults(
   defineProps<{
-    color?: "pink" | "orange" | "default";
+    color?: MapMarkerLabelColors;
     pulse?: boolean;
   }>(),
   {

--- a/resources/camino-trekker/components/MapMarkerLabel/MapMarkerLabel.vue
+++ b/resources/camino-trekker/components/MapMarkerLabel/MapMarkerLabel.vue
@@ -13,7 +13,6 @@
   </div>
 </template>
 <script setup lang="ts">
-// import { MapMarkerLabelColors } from "@/types";
 export type MapMarkerLabelColors = "pink" | "orange" | "default";
 
 withDefaults(

--- a/resources/camino-trekker/components/TourMap/TourMapRoute.vue
+++ b/resources/camino-trekker/components/TourMap/TourMapRoute.vue
@@ -1,0 +1,17 @@
+<template>
+  <MapPolyline
+    :id="`route-${mapStop.id}`"
+    :class="`tour-map-route--${variant}`"
+    :positions="mapStop.route"
+    :variant="variant"
+  />
+</template>
+<script setup lang="ts">
+import MapPolyline from "../MapPolyline/MapPolyline.vue";
+import type { TourMapStop } from "@/types";
+
+defineProps<{
+  mapStop: TourMapStop;
+  variant: "gradient-inactive" | "gradient-active";
+}>();
+</script>

--- a/resources/camino-trekker/components/TourMap/TourMapStarMarker.vue
+++ b/resources/camino-trekker/components/TourMap/TourMapStarMarker.vue
@@ -7,14 +7,13 @@
 </template>
 <script setup lang="ts">
 import MapMarkerLabel from "../MapMarkerLabel/MapMarkerLabel.vue";
-import type { MapMarkerLabelColors } from "@/types";
 import MapMarker from "../MapMarker/MapMarker.vue";
 
 withDefaults(
   defineProps<{
     lng: number;
     lat: number;
-    color?: MapMarkerLabelColors;
+    color?: "pink" | "orange" | "default";
     pulse?: boolean;
     draggable?: boolean;
   }>(),

--- a/resources/camino-trekker/components/TourMap/TourMapStarMarker.vue
+++ b/resources/camino-trekker/components/TourMap/TourMapStarMarker.vue
@@ -1,0 +1,27 @@
+<template>
+  <MapMarker :lng="lng" :lat="lat" :draggable="draggable">
+    <MapMarkerLabel :color="color" :pulse="pulse">
+      <span class="material-icons"> star </span>
+    </MapMarkerLabel>
+  </MapMarker>
+</template>
+<script setup lang="ts">
+import MapMarkerLabel from "../MapMarkerLabel/MapMarkerLabel.vue";
+import type { MapMarkerLabelColors } from "@/types";
+import MapMarker from "../MapMarker/MapMarker.vue";
+
+withDefaults(
+  defineProps<{
+    lng: number;
+    lat: number;
+    color?: MapMarkerLabelColors;
+    pulse?: boolean;
+    draggable?: boolean;
+  }>(),
+  {
+    color: "default",
+    pulse: false,
+    draggable: false,
+  }
+);
+</script>

--- a/resources/camino-trekker/components/TourMap/TourMapStop.vue
+++ b/resources/camino-trekker/components/TourMap/TourMapStop.vue
@@ -1,0 +1,53 @@
+<template>
+  <MapMarker
+    :key="`marker-${mapStop.id}`"
+    :lng="mapStop.stopPoint.lng"
+    :lat="mapStop.stopPoint.lat"
+    :color="mapStop.color"
+    class="tour-map__marker"
+  >
+    <MapMarkerLabel
+      :color="getMapMarkerColor(mapStop)"
+      :pulse="mapStop.isActive"
+    >
+      {{ mapStop.index + 1 }}
+    </MapMarkerLabel>
+    <MapPopup>
+      <p class="map-popup__stop-number-container">
+        <span class="map-popup__stop-number">
+          {{ mapStop.number }}
+        </span>
+      </p>
+      <h2 class="map-popup__stop-title">
+        {{ mapStop.title }}
+      </h2>
+      <p class="map-popup__link-container">
+        <button class="map-popup__link" @click="$emit('click', mapStop)">
+          <span class="material-icons">arrow_forward</span>
+          <span class="sr-only">Go to Stop</span>
+        </button>
+      </p>
+    </MapPopup>
+  </MapMarker>
+</template>
+<script setup lang="ts">
+import MapMarker from "../MapMarker/MapMarker.vue";
+import MapMarkerLabel from "../MapMarkerLabel/MapMarkerLabel.vue";
+import MapPopup from "../MapPopup/MapPopup.vue";
+
+import type { TourMapStop } from "@/types";
+
+defineProps<{
+  mapStop: TourMapStop;
+}>();
+
+defineEmits<{
+  (eventName: "click", stop: TourMapStop);
+}>();
+
+function getMapMarkerColor(stop: TourMapStop): "pink" | "orange" | "default" {
+  if (stop.isActive) return "pink";
+  if (stop.preceedsActive) return "orange";
+  return "default";
+}
+</script>

--- a/resources/types/index.ts
+++ b/resources/types/index.ts
@@ -281,3 +281,23 @@ export enum TourStyle {
   NEXT_STOP = "next_stop",
   ENTIRE_TOUR = "entire_tour",
 }
+
+/**
+ * for drawing a tour stop and routes
+ */
+export interface TourMapStop {
+  id: number;
+  index: number;
+  number: number;
+  title: string;
+  href: string;
+  startPoint: LngLat;
+  stopPoint: LngLat;
+  route: LngLat[];
+  color: string;
+  isActive: boolean;
+  /** immediately prior to active, so acts as a start point */
+  preceedsActive: boolean;
+}
+
+export type MapMarkerLabelColors = "pink" | "orange" | "default";

--- a/resources/types/index.ts
+++ b/resources/types/index.ts
@@ -299,5 +299,3 @@ export interface TourMapStop {
   /** immediately prior to active, so acts as a start point */
   preceedsActive: boolean;
 }
-
-export type MapMarkerLabelColors = "pink" | "orange" | "default";


### PR DESCRIPTION
This fixes an issue were active routes or stops may not appear to the user. 

Draw order matters, so stops/routes that are drawn later will appear on top of earlier routes. If an inactive stop has the same (or similar) location to the active stop, the active stop may be rendered "under" the inactive stop marker, effectively hiding the active stop. 

This changes tour map draw order so that inactive routes and stops are drawn before active routes and stops. Also, the stop preceding the active stop is drawn later so that it appears on the map (as it's start point for the active stop route).

Closes #266

