### PR TITLE
Fix warning: extraneous props inheritance warning

### DIFF
--- a/resources/camino-trekker/components/Markdown/Markdown.vue
+++ b/resources/camino-trekker/components/Markdown/Markdown.vue
@@ -1,5 +1,4 @@
 <template>
-  <!-- eslint-disable vue/no-v-html -->
   <div class="markdown">
     <SanitizedHTML :html="marked.parse(content ?? '')" />
   </div>

--- a/resources/camino-trekker/components/Markdown/Markdown.vue
+++ b/resources/camino-trekker/components/Markdown/Markdown.vue
@@ -1,6 +1,8 @@
 <template>
   <!-- eslint-disable vue/no-v-html -->
-  <SanitizedHTML class="markdown" :html="marked.parse(content ?? '')" />
+  <div class="markdown">
+    <SanitizedHTML :html="marked.parse(content ?? '')" />
+  </div>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
This moves the `markdown` class to the container rather than putting it on `<SanitizeHTML>` element, resolving a warning:

> Extraneous non-props attributes were passed to component but could not be automatically inherited

 `<SanitizeHTML>` is a single `div` with  `v-html` so its contents will be replaced, losing the `class `prop.
