### PR TITLE
Stop map rerenders when stage changes

### DIFF
--- a/resources/camino-creator/components/NavStageRouteMapper.vue
+++ b/resources/camino-creator/components/NavStageRouteMapper.vue
@@ -106,10 +106,10 @@
   </div>
 </template>
 <script setup lang="ts">
-import { ref, computed, nextTick } from "vue";
+import { ref, computed, nextTick, unref } from "vue";
 import useConfig from "@/shared/useConfig";
 import { Map as MapboxMap } from "mapbox-gl";
-import { LngLat, Maybe, TourStopRoute } from "@/types";
+import { LngLat, Maybe, TourStop, TourStopRoute } from "@/types";
 import { useCreatorStore } from "@creator/stores/useCreatorStore";
 import Map from "@trekker/components/Map/Map.vue";
 import MapMarker from "@/camino-trekker/components/MapMarker/MapMarker.vue";
@@ -136,7 +136,6 @@ const emit = defineEmits<{
 const store = useCreatorStore();
 const config = useConfig();
 const mapRef = ref<MapboxMap | null>(null);
-const tour = store.getTour(props.tourId);
 const { coords: geolocationCoords, error: geolocationError } = useGeolocation();
 
 /**
@@ -164,32 +163,34 @@ interface MappedStop {
   currentValuedTargetPoint?: LngLat;
 }
 
-const toMappedStop = (stop, index) => ({
+const toMappedStop = (stop: TourStop, index: number): MappedStop => ({
   id: stop.id,
   index,
   targetPoint: store.getTourStopTargetPoint(props.tourId, stop.id).value,
   route: store.getTourStopRoute(props.tourId, stop.id).value,
 });
 
-const mappedStops = computed((): MappedStop[] =>
-  tour.value.stops.map(toMappedStop)
-);
+// to avoid triggering unnecessary rerenders, avoid
+// using `computed`, and just get the mappedStops
+// at setup time
+// similarly, no need to get a ref to the tour
+// a plain object with suffives since it's only used by mappedStops
+const tour = unref(store.getTour(props.tourId));
+const mappedStops = tour.stops.map(toMappedStop);
 
 const currentStop = computed(
   (): Maybe<MappedStop> =>
-    mappedStops.value.find((s) => s.id === props.stopId) ?? null
+    mappedStops.find((s) => s.id === props.stopId) ?? null
 );
 
 const previousStop = computed((): Maybe<MappedStop> => {
   const currentStopIndex = currentStop.value?.index;
   if (!currentStopIndex) return null;
-  return (
-    mappedStops.value.find((s) => s.index === currentStopIndex - 1) ?? null
-  );
+  return mappedStops.find((s) => s.index === currentStopIndex - 1) ?? null;
 });
 
 const otherStops = computed((): MappedStop[] => {
-  return mappedStops.value.filter((stop) => stop.id !== props.stopId);
+  return mappedStops.filter((stop) => stop.id !== props.stopId);
 });
 
 const routeToNextRoute = computed((): Maybe<TourStopRoute> => {

--- a/resources/camino-creator/components/NavStageRouteMapper.vue
+++ b/resources/camino-creator/components/NavStageRouteMapper.vue
@@ -188,9 +188,7 @@ const previousStop = computed((): Maybe<MappedStop> => {
   );
 });
 
-// calculate this once on mount
 const otherStops = computed((): MappedStop[] => {
-  if (otherStops.value?.length) return otherStops.value;
   return mappedStops.value.filter((stop) => stop.id !== props.stopId);
 });
 

--- a/resources/camino-creator/components/NavStageRouteMapper.vue
+++ b/resources/camino-creator/components/NavStageRouteMapper.vue
@@ -8,7 +8,7 @@
       :accessToken="config.mapBox.accessToken"
       @load="handleMapLoad"
     >
-      <div v-for="stop in otherStops" :key="stop.id">
+      <div v-for="stop in otherStops" v-once :key="stop.id">
         <MapPolyline
           :id="`otherStopRoute-${stop.id}`"
           :positions="stop.route || []"
@@ -188,9 +188,11 @@ const previousStop = computed((): Maybe<MappedStop> => {
   );
 });
 
-const otherStops = computed((): MappedStop[] =>
-  mappedStops.value.filter((stop) => stop.id !== props.stopId)
-);
+// calculate this once on mount
+const otherStops = computed((): MappedStop[] => {
+  if (otherStops.value?.length) return otherStops.value;
+  return mappedStops.value.filter((stop) => stop.id !== props.stopId);
+});
 
 const routeToNextRoute = computed((): Maybe<TourStopRoute> => {
   if (!props.targetPoint) return null;

--- a/resources/camino-creator/components/Stage/Stage.vue
+++ b/resources/camino-creator/components/Stage/Stage.vue
@@ -19,9 +19,6 @@
       <component
         :is="componentName"
         :stage="stage"
-        :languages="tour.tour_content.languages"
-        :tour="tour"
-        :stop="stop"
         :tourId="tourId"
         :stopId="stopId"
         @update="(updatedStage) => $emit('update', updatedStage)"
@@ -44,12 +41,10 @@ import LanguageSelector from "./stages/LanguageSelector.vue";
 import Navigation from "./stages/Navigation.vue";
 import Separator from "./stages/Separator.vue";
 import Quiz from "./stages/Quiz.vue";
-import { Stage, StageType, Tour, TourStop } from "@/types";
+import { Stage, StageType } from "@/types";
 
 interface Props {
   stage: Stage;
-  tour: Tour;
-  stop: TourStop;
   tourId: number;
   stopId: number;
 }

--- a/resources/camino-creator/components/Stage/stages/DeepDiveSummary.vue
+++ b/resources/camino-creator/components/Stage/stages/DeepDiveSummary.vue
@@ -12,14 +12,17 @@
 </template>
 
 <script setup lang="ts">
-import { DeepDiveSummaryStage, Locale, Tour } from "@/types";
+import { DeepDiveSummaryStage } from "@/types";
 import LanguageText from "../../LanguageText.vue";
+import { useCreatorStore } from "@/camino-creator/stores/useCreatorStore";
 
 const props = defineProps<{
   stage: DeepDiveSummaryStage;
-  languages: Locale[];
-  tour: Tour;
+  tourId: number;
 }>();
+
+const creatorStore = useCreatorStore();
+const languages = creatorStore.getTourLanguages(props.tourId);
 
 const emit = defineEmits<{
   (eventName: "update", updatedStage: DeepDiveSummaryStage);

--- a/resources/camino-creator/components/Stage/stages/DeepDives.vue
+++ b/resources/camino-creator/components/Stage/stages/DeepDives.vue
@@ -25,10 +25,7 @@
         <i class="fas fa-trash"></i> Remove Deep Dive
       </button>
     </div>
-    <!-- FIXME: This is mutating the stage prop! Ignoring for now. -->
-    <!-- eslint-disable -->
-    <button @click="addDeepDive" class="btn btn-outline-primary">
-      <!-- eslint-enable -->
+    <button class="btn btn-outline-primary" @click="addDeepDive">
       <i class="fas fa-image"></i> Add Deep Dive
     </button>
   </div>
@@ -37,15 +34,16 @@
 <script setup lang="ts">
 import LanguageText from "../../LanguageText.vue";
 import { createEmptyLocalizedText } from "@/shared/i18n";
-import type { DeepDiveStage, DeepDiveItem, Locale, Stage, Tour } from "@/types";
+import type { DeepDiveStage, DeepDiveItem, Stage } from "@/types";
+import { useCreatorStore } from "@/camino-creator/stores/useCreatorStore";
 
-interface Props {
+const props = defineProps<{
   stage: Stage;
-  languages: Locale[];
-  tour: Tour;
-}
+  tourId: number;
+}>();
 
-const props = defineProps<Props>();
+const creatorStore = useCreatorStore();
+const languages = creatorStore.getTourLanguages(props.tourId);
 
 interface Emits {
   (eventName: "update", payload: DeepDiveStage): void;
@@ -57,8 +55,8 @@ function addDeepDive(): void {
     ...props.stage,
     deepdives: props.stage.deepdives.concat({
       id: global.crypto.randomUUID(),
-      title: createEmptyLocalizedText(props.languages),
-      text: createEmptyLocalizedText(props.languages),
+      title: createEmptyLocalizedText(languages.value),
+      text: createEmptyLocalizedText(languages.value),
     }),
   };
   emit("update", updatedStage);

--- a/resources/camino-creator/components/VEditor/VEditor.vue
+++ b/resources/camino-creator/components/VEditor/VEditor.vue
@@ -11,6 +11,7 @@ import { deepmerge } from "deepmerge-ts";
 import handleUploadImage from "./handleUploadImage";
 import QuillImageUploader from "quill-image-uploader";
 import "quill/dist/quill.snow.css";
+import { useThrottleFn } from "@vueuse/shared";
 
 const props = withDefaults(
   defineProps<{
@@ -70,9 +71,11 @@ onMounted(async () => {
 
   quill.value = new Quill(editorContainerRef.value, quillOptions);
 
-  quill.value.on("text-change", () => {
+  const throttledUpdateModelValue = useThrottleFn(() => {
     emit("update:modelValue", quill.value?.root.innerHTML);
-  });
+  }, 250);
+
+  quill.value.on("text-change", throttledUpdateModelValue);
 
   // set initial editor
   setEditorHTML(props.modelValue);

--- a/resources/camino-creator/pages/TourStopPage/TourStopPage.vue
+++ b/resources/camino-creator/pages/TourStopPage/TourStopPage.vue
@@ -70,8 +70,6 @@
           <template #item="{ element }">
             <Stage
               :stage="element"
-              :tour="tour"
-              :stop="stop"
               :tourId="tourId"
               :stopId="stopId"
               @update="
@@ -174,7 +172,6 @@ const showSaveSuccessful = ref(false);
 const errors = ref<string[]>([]);
 const error = ref(null);
 const router = useRouter();
-const tour = creatorStore.getTour(props.tourId);
 const tourTitle = creatorStore.getTourTitle(props.tourId);
 const tourLanguages = creatorStore.getTourLanguages(props.tourId);
 const defaultTourLanguage = creatorStore.getDefaultTourLanguage(props.tourId);


### PR DESCRIPTION
## Background
In issue #264, within Camino Creator TourStop page, whenever a user edits a stage the navigation map with the tour route will rerender. The user could experience laggy typing and map flickering when this happens.

## Hypothesis
The working hypothesis is that drawing the map with tour stops and routes requires requires reading every stage from every stop. The `mappedStops` computed ref does most this work at setup, making all the stages dependencies of `mappedStops`. So, any stage change, triggers a recompute of mappedStops and anything derived from mappedStops. (And, I think because all stages are dependencies, we're not getting any wins from cached computed values).

## Changes

To stop rerendering and improve performance this PR has two changes:

### 1. Make `tour` and `mappedStops`  plain old objects rather than reactive/computed refs

On a given stop page, a user isn't changing target points or routes for other stops, so there's no need to recalculate the tour or mapped stops after we've done it at setup time. Using `unref` on the `tour` and removing `computed` from `mappedStops` changes them to non-reactive objects, meaning they won't update when other stages changes.

Before: typing in the Guide stage triggers all sorts of Map rerender events.
![camino-rerendering-map-BEFORE](https://user-images.githubusercontent.com/980170/178892434-86229fed-5320-4962-90e0-b6e7cb4c7993.gif)

After we we change `mappedStops` and `tour`, the map is drawn once and updating a stage doesn't trigger a rerender.
![camino-rerender-map-AFTER](https://user-images.githubusercontent.com/980170/178892445-ec12aa80-78d9-4b49-91d5-961f2f7e42b2.gif)

Note: The map is still editable by the user since those changes are emitted and the target marker and editable polyline are derived from map props and not creatorStore state.

### 2. throttle editor updates

The quill editor emits an update with the entire editor contents with each keystroke. This is overkill. 
The PR wraps the `emit` function with `useThrottleFn` and sets the throttle to be 250ms, so the ref will be updated with editor contents no more than 4 times per second. This keeps the editor feeling responsive.

Closes #264 

