### PR TITLE
fix togglling deep dive accordion submits form

### DIFF
--- a/resources/camino-trekker/components/Stage/stages/DeepDivesSummaryItem.vue
+++ b/resources/camino-trekker/components/Stage/stages/DeepDivesSummaryItem.vue
@@ -21,6 +21,7 @@
       </label>
       <button
         class="deepdivesummary-item__show-more-toggle"
+        type="button"
         @click="toggleShowDetails"
       >
         <span class="sr-only">Show More</span>


### PR DESCRIPTION
Fixes an issue where user toggling the show more accordion on a Deep Dive Item may accidentally trigger a form submit.

The DeepDiveItem button is within a form, and any button without a type within a form defaults to `type=submit`, so this PR adds `type="button"`.
