### PR TITLE
[Creator] Change language text label to be left aligned

### DIFF
--- a/resources/camino-creator/components/LanguageText.vue
+++ b/resources/camino-creator/components/LanguageText.vue
@@ -96,6 +96,5 @@ function handleTextUpdate(language: Locale, updatedText: string) {
   font-weight: bold;
   color: #999;
   display: block;
-  text-align: right;
 }
 </style>

--- a/resources/camino-creator/components/VEditor/VEditor.vue
+++ b/resources/camino-creator/components/VEditor/VEditor.vue
@@ -85,8 +85,7 @@ onMounted(async () => {
 .v-editor {
   background: #f3f3f3;
   border-radius: 0.5rem;
-  padding: 1rem;
-  padding-top: 0.5rem;
+  padding: 0.5rem;
 }
 </style>
 


### PR DESCRIPTION
The label on language text was right aligned to remove interface clutter. However, when a stage has more than one language text field (e.g. quiz prompt and quiz hint), it's a bit too out of the way and requires a little thinking to locate. This left aligns the label.