### PR TITLE
Reduce the amount of LocalStorage caching

### DIFF
--- a/resources/camino-trekker/stores/useDeepDivesStore.ts
+++ b/resources/camino-trekker/stores/useDeepDivesStore.ts
@@ -28,7 +28,7 @@ export const useDeepDivesStore = defineStore("deepdives", {
         `${storageKey}.selectedDeepDiveIds`,
         []
       ),
-      email: useStorage<string>(`${storageKey}.email`, ""),
+      email: "",
       sendStatus: "idle" as SendStatus,
       error: "",
     };

--- a/resources/camino-trekker/stores/useFeedbackStore.ts
+++ b/resources/camino-trekker/stores/useFeedbackStore.ts
@@ -1,17 +1,13 @@
 import { defineStore, acceptHMRUpdate } from "pinia";
 import axios from "@/shared/axios";
 import config from "@/camino-trekker/config";
-import { useStorage } from "@vueuse/core";
-import { useTrekkerStore } from "./useTrekkerStore";
 
 export const useFeedbackStore = defineStore("feedback", {
   state: () => {
-    const { tourId } = useTrekkerStore();
-    const storageKey = `camino.trekker.tour-${tourId}.feedbackStore`;
     return {
-      name: useStorage<string>(`${storageKey}.name`, ""),
-      email: useStorage<string>(`${storageKey}.email`, ""),
-      feedback: useStorage<string>(`${storageKey}.feedback`, ""),
+      name: "",
+      email: "",
+      feedback: "",
       isSubmitting: false,
       isNewSubmission: true,
       error: "",

--- a/resources/camino-trekker/stores/useQuizStore.ts
+++ b/resources/camino-trekker/stores/useQuizStore.ts
@@ -1,7 +1,6 @@
 import { defineStore, acceptHMRUpdate } from "pinia";
 import { useTrekkerStore } from "./useTrekkerStore";
 import { QuizChoice, UserQuiz } from "@/types";
-import { useStorage } from "@vueuse/core";
 import getQuizzesFromTour from "../utils/getQuizzesFromTour";
 
 export const useQuizStore = defineStore("quizzes", {
@@ -16,11 +15,8 @@ export const useQuizStore = defineStore("quizzes", {
     );
 
     return {
-      quizzes: useStorage("camino.trekker.quizStore.quizzes", quizzes),
-      quizIdsByStopIndex: useStorage(
-        "camino.trekker.quizStore.quizIdsByStopIndex",
-        quizIdsByStopIndex
-      ),
+      quizzes,
+      quizIdsByStopIndex,
     };
   },
   getters: {

--- a/resources/camino-trekker/stores/useTrekkerStore.ts
+++ b/resources/camino-trekker/stores/useTrekkerStore.ts
@@ -14,7 +14,7 @@ export const useTrekkerStore = defineStore("trekker", {
     const storageKey = `camino.trekker.tour-${route.params.tourId}.trekkerStore`;
 
     return {
-      tour: useStorage<Maybe<Tour>>(`${storageKey}.tour`, null),
+      tour: null as Maybe<Tour>,
       isLoading: true,
       locale: useStorage<Locale>(`${storageKey}.locale`, Locale.en),
       errors: [] as string[],


### PR DESCRIPTION
This reduces the number of things cached in local storage for now, as a workaround for #320 

With this PR, no longer cached in local storage (i.e. a refresh will load the most recent copy):
- the tour
- feedback form
- quizzes and submitted responses

These things will remain saved in local storage:
- selected deep dive ids
- selected tour language (locale)

Going forward, I think my approach of caching with LocalStorage was a dated solution to this problem. Instead we should adopt a more modern approach of using the Cache API (supported by all modern browsers) in service workers with something like [WorkboxJS](https://github.com/GoogleChrome/workbox). Other assets could be cached too, and there's strategies for background updates, manifest generation, and versioning. Basically, I think going full PWA will have more benefits for the user, with fewer cache-busting headaches, for not much more effort.

In the meantime, I think being conservative with our usage of LocalStorage would be better for users, which is the goal of this PR.

I'll open an issue for discussion.

Closes #320 