### PR TITLE
revert bootstrap to 5.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "aframe": "^1.3.0",
     "aframe-look-at-component": "^1.0.0",
     "axios": "^0.27.2",
-    "bootstrap": "^5.2.0",
+    "bootstrap": "~5.1.3",
     "cypress": "9.7.0",
     "deepmerge-ts": "^4.2.1",
     "dompurify": "^2.3.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2778,10 +2778,10 @@ boolbase@^1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
-bootstrap@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.2.0.tgz#838727fb60f1630db370fe57c63cbcf2962bb3d3"
-  integrity sha512-qlnS9GL6YZE6Wnef46GxGv1UpGGzAwO0aPL1yOjzDIJpeApeMvqV24iL+pjr2kU4dduoBA9fINKWKgMToobx9A==
+bootstrap@~5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.1.3.tgz#ba081b0c130f810fa70900acbc1c6d3c28fa8f34"
+  integrity sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==
 
 brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
In 5.2.0, bootstrap changed to CSS variables, which altered how some things render. For example, on the login page the button hover state is transparent, making it unreadable. This is maybe due to a bug with an unset CSS variable. Whatever the case, this commit rolls back the 5.2 update and keeps bootstrap at 5.1.x for now.