### PR TITLE
Feedback Form: disable submit button until all fields have content

### DIFF
--- a/resources/camino-trekker/components/Stage/stages/Feedback.vue
+++ b/resources/camino-trekker/components/Stage/stages/Feedback.vue
@@ -21,7 +21,12 @@
       <Error v-if="feedbackStore.error"> {{ feedbackStore.error }} </Error>
       <div class="feedback-stage__actions">
         <Button variant="link" type="reset">Cancel</Button>
-        <Button type="submit" iconPosition="after">Submit</Button>
+        <Button
+          type="submit"
+          iconPosition="after"
+          :disabled="!feedbackStore.canSubmit"
+          >Submit</Button
+        >
       </div>
     </form>
     <Spinner v-if="feedbackStore.isSubmitting" />

--- a/resources/camino-trekker/stores/useFeedbackStore.ts
+++ b/resources/camino-trekker/stores/useFeedbackStore.ts
@@ -13,6 +13,11 @@ export const useFeedbackStore = defineStore("feedback", {
       error: "",
     };
   },
+  getters: {
+    canSubmit(state) {
+      return state.name && state.email && state.feedback;
+    },
+  },
   actions: {
     softReset() {
       /** keep name and email  */


### PR DESCRIPTION
Small tweak while I noticed it: 

This adds a disabled attribute to the Feedback form submit button if text, email, or name is empty.

The inputs are `required` so the browser was already preventing submission without content, but the `disable` attribute will also indicate to the user that it's disabled (opacity 50%), like other disabled buttons.


