### PR TITLE
fix: trekker stops not working

### DIFF
--- a/resources/camino-trekker/stores/useTrekkerStore.ts
+++ b/resources/camino-trekker/stores/useTrekkerStore.ts
@@ -1,93 +1,95 @@
-import { defineStore, acceptHMRUpdate } from "pinia";
+import { defineStore } from "pinia";
 import { toursService } from "../common/api.service";
-import { Maybe, Tour, TourStop, Locale, BottomNavSheet } from "@/types";
-import { useRoute, RouteLocationNormalizedLoaded } from "vue-router";
+import { Maybe, Tour, Locale, BottomNavSheet } from "@/types";
+import { useRoute } from "vue-router";
 import normalizeTour from "@/shared/normalizeTour";
 import { useStorage } from "@vueuse/core";
+import { reactive, computed, toRefs } from "vue";
 
 const toInt = (str) => Number.parseInt(str, 10);
 
-export const useTrekkerStore = defineStore("trekker", {
-  state: () => {
-    const route = useRoute();
-    const storageKey = `camino.trekker.tour-${route.params.tourId}.trekkerStore`;
+export const useTrekkerStore = defineStore("trekker", () => {
+  const route = useRoute();
+  const storageKey = `camino.trekker.tour-${route.params.tourId}.trekkerStore`;
 
-    return {
-      tour: null as Maybe<Tour>,
-      isLoading: true,
-      locale: useStorage<Locale>(`${storageKey}.locale`, Locale.en),
-      errors: [] as string[],
-      activeSheet: null as Maybe<BottomNavSheet>,
-      route: route as RouteLocationNormalizedLoaded,
-    };
-  },
-  getters: {
-    allStops: (state) => state.tour?.stops ?? [],
-    totalStops: (state) => state.tour?.stops.length ?? 0,
-    stopIndex(state): number {
-      const stopIndex = Array.isArray(state.route.params.stopIndex)
-        ? state.route.params.stopIndex[0]
-        : state.route.params.stopIndex;
-      return Number.parseInt(stopIndex) ?? 0;
-    },
-    tourId(state): number {
-      return toInt(state.route.params.tourId);
-    },
-    isFirstStop(): boolean {
-      return this.stopIndex === 0;
-    },
-    isLastStop(): boolean {
-      return this.stopIndex === this.totalStops - 1;
-    },
-    currentStop(): TourStop {
-      return this.allStops[this.stopIndex];
-    },
-    nextStop(): Maybe<TourStop> {
-      if (this.isLastStop) return null;
-      return this.allStops[this.stopIndex + 1];
-    },
-    previousStop(): Maybe<TourStop> {
-      if (this.isFirstStop) return null;
-      return this.allStops[this.stopIndex - 1];
-    },
-    supportedLocales(state): Locale[] {
-      return state.tour?.tour_content?.languages ?? [];
-    },
-    isActiveSheet:
-      (state) =>
-      (sheetKey: Maybe<BottomNavSheet>): boolean =>
-        state.activeSheet === sheetKey,
-  },
-  actions: {
+  const state = reactive({
+    tour: null as Maybe<Tour>,
+    isLoading: true,
+    locale: useStorage<Locale>(`${storageKey}.locale`, Locale.en),
+    errors: [] as string[],
+    activeSheet: null as Maybe<BottomNavSheet>,
+  });
+
+  const allStops = computed(() => state.tour?.stops ?? []);
+  const totalStops = computed(() => state.tour?.stops.length ?? 0);
+  const stopIndex = computed(() => {
+    const stopIndex = Array.isArray(route.params.stopIndex)
+      ? route.params.stopIndex[0]
+      : route.params.stopIndex;
+    return Number.parseInt(stopIndex) ?? 0;
+  });
+
+  const tourId = computed(() => {
+    return toInt(route.params.tourId);
+  });
+  const isFirstStop = computed(() => stopIndex.value === 0);
+  const isLastStop = computed(() => stopIndex.value === totalStops.value - 1);
+  const currentStop = computed(() => allStops.value[stopIndex.value]);
+  const nextStop = computed(() => {
+    if (isLastStop.value) return null;
+    return allStops.value[stopIndex.value + 1];
+  });
+  const previousStop = computed(() => {
+    if (isFirstStop.value) return null;
+    return allStops.value[stopIndex.value - 1];
+  });
+  const supportedLocales = computed(
+    () => state.tour?.tour_content?.languages ?? []
+  );
+
+  const isActiveSheet = (sheetKey: Maybe<BottomNavSheet>): boolean => {
+    return state.activeSheet === sheetKey;
+  };
+
+  const actions = {
     fetchTour(tourId) {
-      this.isLoading = true;
+      state.isLoading = true;
       toursService
         .get(tourId)
         .then((tour) => {
-          this.isLoading = false;
-          this.tour = normalizeTour(tour);
+          state.isLoading = false;
+          state.tour = normalizeTour(tour);
         })
         .catch((err) => {
           console.error(err);
-          this.isLoading = false;
-          this.errors.push(err);
+          state.isLoading = false;
+          state.errors.push(err);
         });
     },
     setLocale(locale: Locale) {
-      this.locale = locale;
+      state.locale = locale;
     },
     setActiveSheet(sheetKey: Maybe<BottomNavSheet>) {
-      this.activeSheet = sheetKey;
+      state.activeSheet = sheetKey;
     },
     closeActiveSheet() {
-      this.setActiveSheet(null);
+      actions.setActiveSheet(null);
     },
-  },
-});
+  };
 
-// see: https://pinia.vuejs.org/cookbook/hot-module-replacement.html
-if (import.meta.webpackHot) {
-  import.meta.webpackHot.accept(
-    acceptHMRUpdate(useTrekkerStore, import.meta.webpackHot)
-  );
-}
+  return {
+    ...toRefs(state),
+    ...actions,
+    allStops,
+    totalStops,
+    stopIndex,
+    tourId,
+    isFirstStop,
+    isLastStop,
+    currentStop,
+    nextStop,
+    previousStop,
+    supportedLocales,
+    isActiveSheet,
+  };
+});


### PR DESCRIPTION
In Camino Trekker, navigation using stops is broken. This is caused by `useRoute()` generating undefined values in some functions within the pinia `useTrekkerStore`. 

According to the docs, the latest version of pinia wants composables like `useRoute()` to be used in the composition API format (`defineStore` using a function rather than an object). So this refactors the store into the composition api format.

(Tests will be fixed in a forthcoming PR).