### PR TITLE
fix(creator): delete stop header image

### DIFF
--- a/resources/camino-creator/stores/useCreatorStore.ts
+++ b/resources/camino-creator/stores/useCreatorStore.ts
@@ -308,6 +308,7 @@ export const useCreatorStore = defineStore("creator", () => {
       ).value;
 
       const tours = state.tours.value;
+      // Note: 'stop' is a reference to the actual stop object in the state array, not a copy.
       const stop = tours[tourIndex].stops[stopIndex];
       const image = stop.stop_content.header_image;
 

--- a/resources/camino-creator/stores/useCreatorStore.ts
+++ b/resources/camino-creator/stores/useCreatorStore.ts
@@ -306,20 +306,21 @@ export const useCreatorStore = defineStore("creator", () => {
         tourId,
         stopId
       ).value;
-      const image =
-        state.tours[tourIndex].stops[stopIndex].stop_content.header_image;
+
+      const tours = state.tours.value;
+      const stop = tours[tourIndex].stops[stopIndex];
+      const image = stop.stop_content.header_image;
 
       // if no header image found, we're done!
       if (!image) return;
 
       // optimistic update
-      state.tours[tourIndex].stops[stopIndex].stop_content.header_image = null;
+      stop.stop_content.header_image = null;
 
       axios.delete(`/creator/image/${image.src}`).catch((err) => {
         console.error(`cannot delete image`, err);
         //rollback
-        state.tours[tourIndex].stops[stopIndex].stop_content.header_image =
-          image;
+        stop.stop_content.header_image = image;
       });
     },
     /**


### PR DESCRIPTION
`state.tours` is a ref, and so we need to use a`.value` to get the array of all tours.

On dev for testing.

Fixes #481 
